### PR TITLE
Add rightmost failure tracking for better error messages

### DIFF
--- a/docs/superpowers/specs/2026-04-01-rightmost-failure-tracking-design.md
+++ b/docs/superpowers/specs/2026-04-01-rightmost-failure-tracking-design.md
@@ -25,18 +25,19 @@ New functions:
 
 - **`recordFailure(input: string, expected: string)`** — computes `pos = getInputStr().length - input.length`. If `pos > rightmostFailurePos`, resets the expected list to `[expected]`. If `pos === rightmostFailurePos`, appends `expected` (with dedup). No-op if `getInputStr()` is empty (i.e., `setInputStr` was not called).
 - **`getRightmostFailure(): { pos: number, expected: string[] } | null`** — returns the current rightmost failure, or `null` if none recorded.
-- **`getErrorMessage(): string | null`** — formats the rightmost failure using `buildLineTable` + `offsetToPosition` into a human-readable message like `Line 4, col 5: expected "(", a digit, an identifier`. Returns `null` if no failures recorded.
+- **`getErrorMessage(): string | null`** — formats the rightmost failure using `buildLineTable` + `offsetToPosition` into a human-readable message. Uses Oxford-comma formatting with "or" as the conjunction:
+  - 1 item: `Line 4, col 5: expected "a"`
+  - 2 items: `Line 4, col 5: expected "a" or "b"`
+  - 3+ items: `Line 4, col 5: expected "a", "b", or "c"`
+  - Note: `offsetToPosition` returns 0-based line/column, so the implementation adds 1 to both for the display message.
+  - Returns `null` if no failures recorded.
 - **`resetRightmostFailure()`** — internal (not exported), resets `rightmostFailurePos` to `-1` and clears the expected array.
 
 `setInputStr()` calls `resetRightmostFailure()` automatically, so consumers don't need to manage reset.
 
-### 2. Recording failures
+### 2. Recording failures in leaf parsers
 
-Failures are recorded in two places:
-
-**In `trace()`:** After the wrapped parser runs, if it failed, call `recordFailure(input, name)`. This happens on the non-debug path too — not gated behind `DEBUG=1`. Every traced parser contributes its name as an expected alternative at its failure position.
-
-**In leaf parsers (`parsers.ts`):** Each leaf parser calls `recordFailure` directly with a literal-style label:
+Leaf parsers in `parsers.ts` call `recordFailure` directly with a literal-style label on failure:
 
 | Parser | Expected label |
 |--------|---------------|
@@ -46,26 +47,33 @@ Failures are recorded in two places:
 | `oneOf(chars)` | `"one of \"${chars}\""` |
 | `noneOf(chars)` | `"none of \"${chars}\""` |
 | `regexParser(str)` | `"${str}"` |
+| `captureRegex(str)` | `"${str}"` |
 | `anyChar` | `"any character"` |
 | `eof` | `"end of input"` |
 
-Both `trace` and leaf parsers record without filtering. The consumer receives the full set of expectations and can filter if desired.
+Note: `eof` is not wrapped in `trace` (unlike other leaf parsers), so it must record failures directly in its body.
 
-### 3. `label()` internal helper (`parsers.ts`)
+`trace` does **not** record failures. It remains purely a debug-logging mechanism. Only leaf parsers and `label()` record failures.
 
-An internal (not exported) helper for wrapping built-in convenience parsers with friendly names:
+### 3. `label()` — exported combinator (`parsers.ts`)
+
+A public combinator for adding friendly expectation names at any level. On failure, it **suppresses inner recordings** and records only its own name. It does this by saving the rightmost failure state before running the inner parser and restoring it afterward, then recording only the label.
 
 ```ts
-function label<T>(name: string, parser: Parser<T>): Parser<T> {
+export function label<T>(name: string, parser: Parser<T>): Parser<T> {
   return (input: string) => {
+    const saved = saveRightmostFailure();
     const result = parser(input);
+    restoreRightmostFailure(saved);
     if (!result.success) recordFailure(input, name);
     return result;
   };
 }
 ```
 
-Used for:
+This requires two additional internal helpers in `trace.ts`: `saveRightmostFailure()` and `restoreRightmostFailure(saved)`.
+
+Used internally for built-in convenience parsers:
 
 ```ts
 export const digit = label("a digit", oneOf("0123456789"));
@@ -77,7 +85,21 @@ export const num = label("a number", regexParser("^[0-9]+"));
 export const quote = label("a quote", oneOf(`'"`));
 ```
 
-### 4. Consumer API
+Also available to consumers for their own parsers:
+
+```ts
+const identifier = label("an identifier", seq([letter, many(alphanum)], parts => parts.join("")));
+```
+
+### 4. How expectations accumulate in `or`
+
+No changes to `or` are needed. Expectations accumulate naturally because all alternatives in an `or` that fail at the same position each record their labels. For example, `or(digit, letter)` failing at position 5 produces `rightmostFailureExpected = ["a digit", "a letter"]`, and `getErrorMessage()` formats this as:
+
+```
+Line 2, col 3: expected a digit or a letter
+```
+
+### 5. Consumer API
 
 Typical usage:
 
@@ -91,22 +113,27 @@ if (!result.success) {
 
 No new types. No breaking changes. Existing code that doesn't call `setInputStr` is completely unaffected.
 
-### 5. Exports (`index.ts`)
+### 6. Exports
 
-New exports: `recordFailure`, `getRightmostFailure`, `getErrorMessage`.
+New exports from `trace.ts` (automatically re-exported by `index.ts` via `export * from "./trace.js"`):
+- `recordFailure`
+- `getRightmostFailure`
+- `getErrorMessage`
 
-`resetRightmostFailure` is internal only.
+New export from `parsers.ts` (automatically re-exported by `index.ts` via `export * from "./parsers.js"`):
+- `label`
+
+Internal only (not exported from module): `resetRightmostFailure`, `saveRightmostFailure`, `restoreRightmostFailure`.
 
 ## File change summary
 
 | File | Change |
 |------|--------|
-| `trace.ts` | Add rightmost failure state, `recordFailure()`, `getRightmostFailure()`, `getErrorMessage()`. Call reset inside `setInputStr()`. Record failure in `trace()` on non-debug path. |
-| `parsers.ts` | Add internal `label()` helper. Add `recordFailure` calls in `char`, `str`, `istr`, `oneOf`, `noneOf`, `regexParser`, `anyChar`, `eof`. Wrap `digit`, `space`, `letter`, `alphanum`, `word`, `num`, `quote` with `label()`. |
-| `index.ts` | Re-export `recordFailure`, `getRightmostFailure`, `getErrorMessage`. |
+| `trace.ts` | Add rightmost failure state, `recordFailure()`, `getRightmostFailure()`, `getErrorMessage()`, `saveRightmostFailure()`, `restoreRightmostFailure()`. Call reset inside `setInputStr()`. |
+| `parsers.ts` | Add exported `label()` combinator. Add `recordFailure` calls in `char`, `str`, `istr`, `oneOf`, `noneOf`, `regexParser`, `captureRegex`, `anyChar`, `eof`. Wrap `digit`, `space`, `letter`, `alphanum`, `word`, `num`, `quote` with `label()`. |
 | `tests/` | New test file for rightmost failure tracking. |
 
-No changes to `types.ts`, `position.ts`, `combinators.ts`, or `tarsecError.ts`.
+No changes to `types.ts`, `position.ts`, `combinators.ts`, `tarsecError.ts`, or `index.ts`.
 
 ## What this doesn't solve
 
@@ -116,4 +143,6 @@ No changes to `types.ts`, `position.ts`, `combinators.ts`, or `tarsecError.ts`.
 
 ## Performance
 
-`recordFailure` is called on every leaf parser failure and every `trace` failure, which happens many times during normal backtracking. The operation is cheap: one integer comparison, possibly an `includes` check and array push. No allocation on the hot path (when `pos < rightmostFailurePos`).
+`recordFailure` is called on every leaf parser failure, which happens many times during normal backtracking. The operation is cheap: one integer comparison, possibly an `includes` check and array push. No allocation on the hot path (when `pos < rightmostFailurePos`).
+
+`label()` adds save/restore overhead (copying the expected array), but this only happens at labeled boundaries, not on every parser call.

--- a/docs/superpowers/specs/2026-04-01-rightmost-failure-tracking-design.md
+++ b/docs/superpowers/specs/2026-04-01-rightmost-failure-tracking-design.md
@@ -1,0 +1,119 @@
+# Rightmost Failure Tracking for Better Error Reporting
+
+## Problem
+
+When a parse fails, tarsec's error messages are unhelpful. `or` returns `"all parsers failed"` with no context. Leaf parser failures like `char`, `str`, `oneOf` produce specific messages (`expected "}", got "i"`) but these get discarded as failures propagate up through combinators.
+
+Ohm.js solves this by tracking the **rightmost failure position** globally. Every time a rule fails, it checks whether this failure is further right than any previous failure. When the overall parse fails, it reports the expected alternatives at that rightmost position. This works because the rightmost failure almost always corresponds to the user's actual mistake.
+
+## Approach
+
+Module-level state in `trace.ts` (Approach A), consistent with the existing `inputStr` pattern. No changes to `Parser<T>`, `ParserFailure`, or any type signatures. Purely additive.
+
+## Design
+
+### 1. State and core functions (`trace.ts`)
+
+New module-level variables alongside `inputStr`:
+
+```ts
+let rightmostFailurePos = -1;
+let rightmostFailureExpected: string[] = [];
+```
+
+New functions:
+
+- **`recordFailure(input: string, expected: string)`** — computes `pos = getInputStr().length - input.length`. If `pos > rightmostFailurePos`, resets the expected list to `[expected]`. If `pos === rightmostFailurePos`, appends `expected` (with dedup). No-op if `getInputStr()` is empty (i.e., `setInputStr` was not called).
+- **`getRightmostFailure(): { pos: number, expected: string[] } | null`** — returns the current rightmost failure, or `null` if none recorded.
+- **`getErrorMessage(): string | null`** — formats the rightmost failure using `buildLineTable` + `offsetToPosition` into a human-readable message like `Line 4, col 5: expected "(", a digit, an identifier`. Returns `null` if no failures recorded.
+- **`resetRightmostFailure()`** — internal (not exported), resets `rightmostFailurePos` to `-1` and clears the expected array.
+
+`setInputStr()` calls `resetRightmostFailure()` automatically, so consumers don't need to manage reset.
+
+### 2. Recording failures
+
+Failures are recorded in two places:
+
+**In `trace()`:** After the wrapped parser runs, if it failed, call `recordFailure(input, name)`. This happens on the non-debug path too — not gated behind `DEBUG=1`. Every traced parser contributes its name as an expected alternative at its failure position.
+
+**In leaf parsers (`parsers.ts`):** Each leaf parser calls `recordFailure` directly with a literal-style label:
+
+| Parser | Expected label |
+|--------|---------------|
+| `char(c)` | `"\"${c}\""` |
+| `str(s)` | `"\"${s}\""` |
+| `istr(s)` | `"\"${s}\""` |
+| `oneOf(chars)` | `"one of \"${chars}\""` |
+| `noneOf(chars)` | `"none of \"${chars}\""` |
+| `regexParser(str)` | `"${str}"` |
+| `anyChar` | `"any character"` |
+| `eof` | `"end of input"` |
+
+Both `trace` and leaf parsers record without filtering. The consumer receives the full set of expectations and can filter if desired.
+
+### 3. `label()` internal helper (`parsers.ts`)
+
+An internal (not exported) helper for wrapping built-in convenience parsers with friendly names:
+
+```ts
+function label<T>(name: string, parser: Parser<T>): Parser<T> {
+  return (input: string) => {
+    const result = parser(input);
+    if (!result.success) recordFailure(input, name);
+    return result;
+  };
+}
+```
+
+Used for:
+
+```ts
+export const digit = label("a digit", oneOf("0123456789"));
+export const space = label("whitespace", oneOf(" \t\n\r"));
+export const letter = label("a letter", oneOf("abcdef..."));
+export const alphanum = label("a letter or digit", oneOf("abcdef...0123456789"));
+export const word = label("a word", regexParser("^[a-z]+", "ui"));
+export const num = label("a number", regexParser("^[0-9]+"));
+export const quote = label("a quote", oneOf(`'"`));
+```
+
+### 4. Consumer API
+
+Typical usage:
+
+```ts
+setInputStr(input);           // also resets rightmost failure state
+const result = myParser(input);
+if (!result.success) {
+  const msg = getErrorMessage(); // "Line 4, col 5: expected ..."
+}
+```
+
+No new types. No breaking changes. Existing code that doesn't call `setInputStr` is completely unaffected.
+
+### 5. Exports (`index.ts`)
+
+New exports: `recordFailure`, `getRightmostFailure`, `getErrorMessage`.
+
+`resetRightmostFailure` is internal only.
+
+## File change summary
+
+| File | Change |
+|------|--------|
+| `trace.ts` | Add rightmost failure state, `recordFailure()`, `getRightmostFailure()`, `getErrorMessage()`. Call reset inside `setInputStr()`. Record failure in `trace()` on non-debug path. |
+| `parsers.ts` | Add internal `label()` helper. Add `recordFailure` calls in `char`, `str`, `istr`, `oneOf`, `noneOf`, `regexParser`, `anyChar`, `eof`. Wrap `digit`, `space`, `letter`, `alphanum`, `word`, `num`, `quote` with `label()`. |
+| `index.ts` | Re-export `recordFailure`, `getRightmostFailure`, `getErrorMessage`. |
+| `tests/` | New test file for rightmost failure tracking. |
+
+No changes to `types.ts`, `position.ts`, `combinators.ts`, or `tarsecError.ts`.
+
+## What this doesn't solve
+
+- **Recovery** — only improves the error message, doesn't help the parser recover and continue.
+- **Multiple errors** — reports the single best error location.
+- **Contextual messages** — the rightmost failure tells you *what* was expected but not *why*. `parseError` is still better for contextual messages like "expected function body after `def foo()`". The two approaches are complementary.
+
+## Performance
+
+`recordFailure` is called on every leaf parser failure and every `trace` failure, which happens many times during normal backtracking. The operation is cheap: one integer comparison, possibly an `includes` check and array push. No allocation on the hot path (when `pos < rightmostFailurePos`).

--- a/docs/superpowers/specs/2026-04-01-rightmost-failure-tracking-design.md
+++ b/docs/superpowers/specs/2026-04-01-rightmost-failure-tracking-design.md
@@ -12,9 +12,9 @@ Module-level state in `trace.ts` (Approach A), consistent with the existing `inp
 
 ## Design
 
-### 1. State and core functions (`trace.ts`)
+### 1. State and core functions (`rightmostFailure.ts`)
 
-New module-level variables alongside `inputStr`:
+New module-level variables:
 
 ```ts
 let rightmostFailurePos = -1;
@@ -33,7 +33,7 @@ New functions:
   - Returns `null` if no failures recorded.
 - **`resetRightmostFailure()`** — internal (not exported), resets `rightmostFailurePos` to `-1` and clears the expected array.
 
-`setInputStr()` calls `resetRightmostFailure()` automatically, so consumers don't need to manage reset.
+`setInputStr()` (in `trace.ts`) imports and calls `resetRightmostFailure()` automatically, so consumers don't need to manage reset.
 
 ### 2. Recording failures in leaf parsers
 
@@ -115,25 +115,28 @@ No new types. No breaking changes. Existing code that doesn't call `setInputStr`
 
 ### 6. Exports
 
-New exports from `trace.ts` (automatically re-exported by `index.ts` via `export * from "./trace.js"`):
+New exports from `rightmostFailure.ts` (re-exported by `index.ts` via `export * from "./rightmostFailure.js"`):
 - `recordFailure`
 - `getRightmostFailure`
 - `getErrorMessage`
+- `resetRightmostFailure`
+- `saveRightmostFailure`
+- `restoreRightmostFailure`
 
 New export from `parsers.ts` (automatically re-exported by `index.ts` via `export * from "./parsers.js"`):
 - `label`
-
-Internal only (not exported from module): `resetRightmostFailure`, `saveRightmostFailure`, `restoreRightmostFailure`.
 
 ## File change summary
 
 | File | Change |
 |------|--------|
-| `trace.ts` | Add rightmost failure state, `recordFailure()`, `getRightmostFailure()`, `getErrorMessage()`, `saveRightmostFailure()`, `restoreRightmostFailure()`. Call reset inside `setInputStr()`. |
+| `rightmostFailure.ts` | New module. Rightmost failure state, `recordFailure()`, `getRightmostFailure()`, `getErrorMessage()`, `saveRightmostFailure()`, `restoreRightmostFailure()`, `resetRightmostFailure()`. |
+| `trace.ts` | Import `resetRightmostFailure` from `rightmostFailure.ts`. Call it inside `setInputStr()`. |
 | `parsers.ts` | Add exported `label()` combinator. Add `recordFailure` calls in `char`, `str`, `istr`, `oneOf`, `noneOf`, `regexParser`, `captureRegex`, `anyChar`, `eof`. Wrap `digit`, `space`, `letter`, `alphanum`, `word`, `num`, `quote` with `label()`. |
+| `index.ts` | Re-export `rightmostFailure.ts`. |
 | `tests/` | New test file for rightmost failure tracking. |
 
-No changes to `types.ts`, `position.ts`, `combinators.ts`, `tarsecError.ts`, or `index.ts`.
+No changes to `types.ts`, `position.ts`, `combinators.ts`, or `tarsecError.ts`.
 
 ## What this doesn't solve
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,3 +4,4 @@ export * from "./trace.js";
 export * from "./types.js";
 export * from "./tarsecError.js";
 export * from "./position.js";
+export * from "./rightmostFailure.js";

--- a/lib/parsers.ts
+++ b/lib/parsers.ts
@@ -1,5 +1,6 @@
 import { many1WithJoin, manyWithJoin, seq } from "./combinators.js";
-import { trace, recordFailure, saveRightmostFailure, restoreRightmostFailure } from "./trace.js";
+import { trace } from "./trace.js";
+import { recordFailure, saveRightmostFailure, restoreRightmostFailure } from "./rightmostFailure.js";
 import {
   CaptureParser,
   captureSuccess,

--- a/lib/parsers.ts
+++ b/lib/parsers.ts
@@ -20,11 +20,8 @@ export { within } from "./parsers/within.js";
 export function char<const S extends string>(c: S): Parser<S> {
   return trace(`char(${escape(c)})`, (input: string) => {
     if (input.length === 0) {
-      return {
-        success: false,
-        rest: input,
-        message: "unexpected end of input",
-      };
+      recordFailure(input, `"${c}"`);
+      return failure("unexpected end of input", input);
     }
     if (input[0] === c) {
       return success(c, input.slice(1));
@@ -77,6 +74,7 @@ export function istr<const S extends string>(s: S): Parser<S> {
 export function oneOf(chars: string): Parser<string> {
   return trace(`oneOf(${escape(chars)})`, (input: string) => {
     if (input.length === 0) {
+      recordFailure(input, `one of "${chars}"`);
       return failure("unexpected end of input", input);
     }
     const c = input[0];
@@ -98,6 +96,7 @@ export function oneOf(chars: string): Parser<string> {
 export function noneOf(chars: string): Parser<string> {
   return trace(`noneOf(${escape(chars)})`, (input: string) => {
     if (input.length === 0) {
+      recordFailure(input, `none of "${chars}"`);
       return failure("unexpected end of input", input);
     }
     if (chars.includes(input[0])) {

--- a/lib/parsers.ts
+++ b/lib/parsers.ts
@@ -1,5 +1,5 @@
 import { many1WithJoin, manyWithJoin, seq } from "./combinators.js";
-import { trace } from "./trace.js";
+import { trace, recordFailure, saveRightmostFailure, restoreRightmostFailure } from "./trace.js";
 import {
   CaptureParser,
   captureSuccess,
@@ -29,6 +29,7 @@ export function char<const S extends string>(c: S): Parser<S> {
     if (input[0] === c) {
       return success(c, input.slice(1));
     }
+    recordFailure(input, `"${c}"`);
     return failure(`expected ${escape(c)}, got ${escape(input[0])}`, input);
   });
 }
@@ -44,6 +45,7 @@ export function str<const S extends string>(s: S): Parser<S> {
     if (input.substring(0, s.length) === s) {
       return success(s, input.slice(s.length));
     }
+    recordFailure(input, `"${s}"`);
     return failure(`expected ${s}, got ${input.substring(0, s.length)}`, input);
   });
 }
@@ -60,6 +62,7 @@ export function istr<const S extends string>(s: S): Parser<S> {
     ) {
       return success(input.substring(0, s.length) as S, input.slice(s.length));
     }
+    recordFailure(input, `"${s}"`);
     return failure(`expected ${s}, got ${input.substring(0, s.length)}`, input);
   });
 }
@@ -80,6 +83,7 @@ export function oneOf(chars: string): Parser<string> {
     if (chars.includes(c)) {
       return char(c)(input);
     }
+    recordFailure(input, `one of "${chars}"`);
     return failure(`expected one of ${escape(chars)}, got ${c}`, input);
   });
 }
@@ -97,6 +101,7 @@ export function noneOf(chars: string): Parser<string> {
       return failure("unexpected end of input", input);
     }
     if (chars.includes(input[0])) {
+      recordFailure(input, `none of "${chars}"`);
       return failure(
         `expected none of ${escape(chars)}, got ${input[0]}`,
         input
@@ -115,38 +120,60 @@ export function noneOf(chars: string): Parser<string> {
  */
 export const anyChar: Parser<string> = trace("anyChar", (input: string) => {
   if (input.length === 0) {
+    recordFailure(input, "any character");
     return failure("unexpected end of input", input);
   }
   return success(input[0], input.slice(1));
 });
 
+/**
+ * Wraps a parser with a human-readable label for error reporting.
+ * On failure, suppresses any inner failure recordings and records only the label.
+ * This produces clean error messages like `expected a digit` instead of `expected one of "0123456789"`.
+ *
+ * @param name - human-readable description of what the parser expects
+ * @param parser - the parser to wrap
+ * @returns - a parser that records the label on failure
+ */
+export function label<T>(name: string, parser: Parser<T>): Parser<T> {
+  return (input: string) => {
+    const saved = saveRightmostFailure();
+    const result = parser(input);
+    restoreRightmostFailure(saved);
+    if (!result.success) recordFailure(input, name);
+    return result;
+  };
+}
+
 /** A parser that matches one of " \t\n\r". */
-export const space: Parser<string> = oneOf(" \t\n\r");
+export const space: Parser<string> = label("whitespace", oneOf(" \t\n\r"));
 
 /** A parser that matches one or more spaces. */
 export const spaces: Parser<string> = many1WithJoin(space);
 
 /** A parser that matches one digit. */
-export const digit: Parser<string> = oneOf("0123456789");
+export const digit: Parser<string> = label("a digit", oneOf("0123456789"));
 
 /** A parser that matches one letter, case insensitive. */
-export const letter: Parser<string> = oneOf(
-  "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+export const letter: Parser<string> = label(
+  "a letter",
+  oneOf("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 );
 
 /** A parser that matches one digit or letter, case insensitive. */
-export const alphanum: Parser<string> = oneOf(
-  "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+export const alphanum: Parser<string> = label(
+  "a letter or digit",
+  oneOf("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
 );
 
 /** A parser that matches one word, case insensitive. */
-export const word: Parser<string> = regexParser("^[a-z]+", "ui");
+export const word: Parser<string> = label("a word", regexParser("^[a-z]+", "ui"));
 
 /** A parser that matches one or more digits. */
-export const num: Parser<string> = regexParser("^[0-9]+");
+export const num: Parser<string> = label("a number", regexParser("^[0-9]+"));
 
 /** A parser that matches one single or double quote. */
-export const quote: Parser<string> = oneOf(`'"`);
+export const quote: Parser<string> = label("a quote", oneOf(`'"`));
 
 /** A parser that matches one tab character. */
 export const tab: Parser<string> = char("\t");
@@ -159,6 +186,7 @@ export const eof: Parser<null> = (input: string) => {
   if (input === "") {
     return success(null, input);
   }
+  recordFailure(input, "end of input");
   return failure("expected end of input", input);
 };
 
@@ -194,6 +222,7 @@ export function regexParser(
     if (match) {
       return success(match[0], input.slice(match[0].length));
     }
+    recordFailure(input, `${str}`);
     return failure(`expected ${str}, got ${input.slice(0, 10)}`, input);
   });
 }
@@ -242,6 +271,7 @@ export function captureRegex<const T extends string[]>(
       } as Record<(typeof captureNames)[number], string>;
       return success(captures, input.slice(match[0].length));
     }
+    recordFailure(input, `${str}`);
     return failure(`expected ${str}, got ${input.slice(0, 10)}`, input);
   }
 

--- a/lib/rightmostFailure.ts
+++ b/lib/rightmostFailure.ts
@@ -55,7 +55,7 @@ export function saveRightmostFailure(): SavedRightmostFailure {
 
 export function restoreRightmostFailure(saved: SavedRightmostFailure) {
   rightmostFailurePos = saved.pos;
-  rightmostFailureExpected = saved.expected;
+  rightmostFailureExpected = [...saved.expected];
 }
 
 function formatExpected(expected: string[]): string {

--- a/lib/rightmostFailure.ts
+++ b/lib/rightmostFailure.ts
@@ -1,0 +1,80 @@
+import { getInputStr } from "./trace.js";
+import { buildLineTable, offsetToPosition } from "./position.js";
+
+let rightmostFailurePos = -1;
+let rightmostFailureExpected: string[] = [];
+
+export function resetRightmostFailure() {
+  rightmostFailurePos = -1;
+  rightmostFailureExpected = [];
+}
+
+/**
+ * Record an expected alternative at the current failure position.
+ * If this position is further right than any previous failure, it replaces the previous.
+ * If it's at the same position, it adds to the list of expectations (with dedup).
+ * No-op if `setInputStr` has not been called.
+ *
+ * @param input - the remaining input at the point of failure
+ * @param expected - a human-readable description of what was expected
+ */
+export function recordFailure(input: string, expected: string) {
+  const source = getInputStr();
+  if (source.length === 0) return;
+  const pos = source.length - input.length;
+  if (pos > rightmostFailurePos) {
+    rightmostFailurePos = pos;
+    rightmostFailureExpected = [expected];
+  } else if (pos === rightmostFailurePos) {
+    if (!rightmostFailureExpected.includes(expected)) {
+      rightmostFailureExpected.push(expected);
+    }
+  }
+}
+
+/**
+ * Returns the current rightmost failure position and expected alternatives,
+ * or `null` if no failures have been recorded.
+ */
+export function getRightmostFailure(): {
+  pos: number;
+  expected: string[];
+} | null {
+  if (rightmostFailurePos < 0) return null;
+  return { pos: rightmostFailurePos, expected: [...rightmostFailureExpected] };
+}
+
+type SavedRightmostFailure = {
+  pos: number;
+  expected: string[];
+};
+
+export function saveRightmostFailure(): SavedRightmostFailure {
+  return { pos: rightmostFailurePos, expected: [...rightmostFailureExpected] };
+}
+
+export function restoreRightmostFailure(saved: SavedRightmostFailure) {
+  rightmostFailurePos = saved.pos;
+  rightmostFailureExpected = saved.expected;
+}
+
+function formatExpected(expected: string[]): string {
+  if (expected.length === 1) return expected[0];
+  if (expected.length === 2) return `${expected[0]} or ${expected[1]}`;
+  return expected.slice(0, -1).join(", ") + ", or " + expected[expected.length - 1];
+}
+
+/**
+ * Formats the rightmost failure into a human-readable error message with line and column info.
+ * Returns `null` if no failures have been recorded.
+ * Requires `setInputStr` to have been called.
+ */
+export function getErrorMessage(): string | null {
+  if (rightmostFailurePos < 0) return null;
+  const source = getInputStr();
+  const lineTable = buildLineTable(source);
+  const pos = offsetToPosition(lineTable, rightmostFailurePos);
+  const line = pos.line + 1;
+  const column = pos.column + 1;
+  return `Line ${line}, col ${column}: expected ${formatExpected(rightmostFailureExpected)}`;
+}

--- a/lib/trace.ts
+++ b/lib/trace.ts
@@ -320,6 +320,7 @@ let inputStr = "";
  */
 export function setInputStr(s: string) {
   inputStr = s;
+  resetRightmostFailure();
 }
 
 export function getInputStr(): string {
@@ -370,4 +371,99 @@ export function getDiagnostics(
       message: message,
     };
   }
+}
+
+// --- Rightmost failure tracking ---
+
+let rightmostFailurePos = -1;
+let rightmostFailureExpected: string[] = [];
+
+function resetRightmostFailure() {
+  rightmostFailurePos = -1;
+  rightmostFailureExpected = [];
+}
+
+/**
+ * Record an expected alternative at the current failure position.
+ * If this position is further right than any previous failure, it replaces the previous.
+ * If it's at the same position, it adds to the list of expectations (with dedup).
+ * No-op if `setInputStr` has not been called.
+ *
+ * @param input - the remaining input at the point of failure
+ * @param expected - a human-readable description of what was expected
+ */
+export function recordFailure(input: string, expected: string) {
+  const source = getInputStr();
+  if (source.length === 0) return;
+  const pos = source.length - input.length;
+  if (pos > rightmostFailurePos) {
+    rightmostFailurePos = pos;
+    rightmostFailureExpected = [expected];
+  } else if (pos === rightmostFailurePos) {
+    if (!rightmostFailureExpected.includes(expected)) {
+      rightmostFailureExpected.push(expected);
+    }
+  }
+}
+
+/**
+ * Returns the current rightmost failure position and expected alternatives,
+ * or `null` if no failures have been recorded.
+ */
+export function getRightmostFailure(): {
+  pos: number;
+  expected: string[];
+} | null {
+  if (rightmostFailurePos < 0) return null;
+  return { pos: rightmostFailurePos, expected: rightmostFailureExpected };
+}
+
+type SavedRightmostFailure = {
+  pos: number;
+  expected: string[];
+};
+
+export function saveRightmostFailure(): SavedRightmostFailure {
+  return { pos: rightmostFailurePos, expected: [...rightmostFailureExpected] };
+}
+
+export function restoreRightmostFailure(saved: SavedRightmostFailure) {
+  rightmostFailurePos = saved.pos;
+  rightmostFailureExpected = saved.expected;
+}
+
+function formatExpected(expected: string[]): string {
+  if (expected.length === 1) return expected[0];
+  if (expected.length === 2) return `${expected[0]} or ${expected[1]}`;
+  return expected.slice(0, -1).join(", ") + ", or " + expected[expected.length - 1];
+}
+
+/**
+ * Formats the rightmost failure into a human-readable error message with line and column info.
+ * Returns `null` if no failures have been recorded.
+ * Requires `setInputStr` to have been called.
+ */
+export function getErrorMessage(): string | null {
+  if (rightmostFailurePos < 0) return null;
+  const source = getInputStr();
+  // Inline line table + offset-to-position to avoid circular import with position.ts
+  const lineStarts = [0];
+  for (let i = 0; i < source.length; i++) {
+    if (source[i] === "\n") {
+      lineStarts.push(i + 1);
+    }
+  }
+  let lo = 0;
+  let hi = lineStarts.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1;
+    if (lineStarts[mid] <= rightmostFailurePos) {
+      lo = mid;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  const line = lo + 1;
+  const column = rightmostFailurePos - lineStarts[lo] + 1;
+  return `Line ${line}, col ${column}: expected ${formatExpected(rightmostFailureExpected)}`;
 }

--- a/lib/trace.ts
+++ b/lib/trace.ts
@@ -415,7 +415,7 @@ export function getRightmostFailure(): {
   expected: string[];
 } | null {
   if (rightmostFailurePos < 0) return null;
-  return { pos: rightmostFailurePos, expected: rightmostFailureExpected };
+  return { pos: rightmostFailurePos, expected: [...rightmostFailureExpected] };
 }
 
 type SavedRightmostFailure = {

--- a/lib/trace.ts
+++ b/lib/trace.ts
@@ -10,6 +10,7 @@ import { escape, round, shorten } from "./utils.js";
 import process from "process";
 import { execSync } from "child_process";
 import { TarsecErrorData } from "./tarsecError.js";
+import { resetRightmostFailure } from "./rightmostFailure.js";
 
 const isNode =
   typeof process !== "undefined" &&
@@ -371,99 +372,4 @@ export function getDiagnostics(
       message: message,
     };
   }
-}
-
-// --- Rightmost failure tracking ---
-
-let rightmostFailurePos = -1;
-let rightmostFailureExpected: string[] = [];
-
-function resetRightmostFailure() {
-  rightmostFailurePos = -1;
-  rightmostFailureExpected = [];
-}
-
-/**
- * Record an expected alternative at the current failure position.
- * If this position is further right than any previous failure, it replaces the previous.
- * If it's at the same position, it adds to the list of expectations (with dedup).
- * No-op if `setInputStr` has not been called.
- *
- * @param input - the remaining input at the point of failure
- * @param expected - a human-readable description of what was expected
- */
-export function recordFailure(input: string, expected: string) {
-  const source = getInputStr();
-  if (source.length === 0) return;
-  const pos = source.length - input.length;
-  if (pos > rightmostFailurePos) {
-    rightmostFailurePos = pos;
-    rightmostFailureExpected = [expected];
-  } else if (pos === rightmostFailurePos) {
-    if (!rightmostFailureExpected.includes(expected)) {
-      rightmostFailureExpected.push(expected);
-    }
-  }
-}
-
-/**
- * Returns the current rightmost failure position and expected alternatives,
- * or `null` if no failures have been recorded.
- */
-export function getRightmostFailure(): {
-  pos: number;
-  expected: string[];
-} | null {
-  if (rightmostFailurePos < 0) return null;
-  return { pos: rightmostFailurePos, expected: [...rightmostFailureExpected] };
-}
-
-type SavedRightmostFailure = {
-  pos: number;
-  expected: string[];
-};
-
-export function saveRightmostFailure(): SavedRightmostFailure {
-  return { pos: rightmostFailurePos, expected: [...rightmostFailureExpected] };
-}
-
-export function restoreRightmostFailure(saved: SavedRightmostFailure) {
-  rightmostFailurePos = saved.pos;
-  rightmostFailureExpected = saved.expected;
-}
-
-function formatExpected(expected: string[]): string {
-  if (expected.length === 1) return expected[0];
-  if (expected.length === 2) return `${expected[0]} or ${expected[1]}`;
-  return expected.slice(0, -1).join(", ") + ", or " + expected[expected.length - 1];
-}
-
-/**
- * Formats the rightmost failure into a human-readable error message with line and column info.
- * Returns `null` if no failures have been recorded.
- * Requires `setInputStr` to have been called.
- */
-export function getErrorMessage(): string | null {
-  if (rightmostFailurePos < 0) return null;
-  const source = getInputStr();
-  // Inline line table + offset-to-position to avoid circular import with position.ts
-  const lineStarts = [0];
-  for (let i = 0; i < source.length; i++) {
-    if (source[i] === "\n") {
-      lineStarts.push(i + 1);
-    }
-  }
-  let lo = 0;
-  let hi = lineStarts.length - 1;
-  while (lo < hi) {
-    const mid = (lo + hi + 1) >> 1;
-    if (lineStarts[mid] <= rightmostFailurePos) {
-      lo = mid;
-    } else {
-      hi = mid - 1;
-    }
-  }
-  const line = lo + 1;
-  const column = rightmostFailurePos - lineStarts[lo] + 1;
-  return `Line ${line}, col ${column}: expected ${formatExpected(rightmostFailureExpected)}`;
 }

--- a/tests/rightmostFailure.test.ts
+++ b/tests/rightmostFailure.test.ts
@@ -13,7 +13,7 @@ describe("rightmost failure tracking", () => {
   });
 
   describe("recordFailure", () => {
-    it("is a no-op when setInputStr has not been called", () => {
+    it("is a no-op when the input string is empty", () => {
       recordFailure("abc", "something");
       expect(getRightmostFailure()).toBeNull();
     });

--- a/tests/rightmostFailure.test.ts
+++ b/tests/rightmostFailure.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  setInputStr,
+  recordFailure,
+  getRightmostFailure,
+  getErrorMessage,
+} from "@/lib/trace.js";
+import { char, str, digit, letter, or, label } from "@/lib/index.js";
+
+describe("rightmost failure tracking", () => {
+  beforeEach(() => {
+    setInputStr(""); // reset state
+  });
+
+  describe("recordFailure", () => {
+    it("is a no-op when setInputStr has not been called", () => {
+      recordFailure("abc", "something");
+      expect(getRightmostFailure()).toBeNull();
+    });
+
+    it("records a failure at the correct position", () => {
+      setInputStr("abcdef");
+      recordFailure("def", '"x"');
+      expect(getRightmostFailure()).toEqual({
+        pos: 3,
+        expected: ['"x"'],
+      });
+    });
+
+    it("replaces expectations when a further-right failure is recorded", () => {
+      setInputStr("abcdef");
+      recordFailure("def", '"x"');
+      recordFailure("ef", '"y"');
+      expect(getRightmostFailure()).toEqual({
+        pos: 4,
+        expected: ['"y"'],
+      });
+    });
+
+    it("accumulates expectations at the same position", () => {
+      setInputStr("abcdef");
+      recordFailure("def", '"x"');
+      recordFailure("def", '"y"');
+      expect(getRightmostFailure()).toEqual({
+        pos: 3,
+        expected: ['"x"', '"y"'],
+      });
+    });
+
+    it("deduplicates expectations at the same position", () => {
+      setInputStr("abcdef");
+      recordFailure("def", '"x"');
+      recordFailure("def", '"x"');
+      expect(getRightmostFailure()).toEqual({
+        pos: 3,
+        expected: ['"x"'],
+      });
+    });
+
+    it("ignores failures to the left of the rightmost", () => {
+      setInputStr("abcdef");
+      recordFailure("ef", '"y"');
+      recordFailure("def", '"x"');
+      expect(getRightmostFailure()).toEqual({
+        pos: 4,
+        expected: ['"y"'],
+      });
+    });
+  });
+
+  describe("setInputStr resets state", () => {
+    it("clears previous failures when setInputStr is called again", () => {
+      setInputStr("abc");
+      recordFailure("c", '"x"');
+      expect(getRightmostFailure()).not.toBeNull();
+
+      setInputStr("def");
+      expect(getRightmostFailure()).toBeNull();
+    });
+  });
+
+  describe("getErrorMessage", () => {
+    it("returns null when no failures recorded", () => {
+      setInputStr("abc");
+      expect(getErrorMessage()).toBeNull();
+    });
+
+    it("formats a single expectation", () => {
+      setInputStr("abc");
+      recordFailure("c", '"x"');
+      expect(getErrorMessage()).toBe('Line 1, col 3: expected "x"');
+    });
+
+    it("formats two expectations with 'or'", () => {
+      setInputStr("abc");
+      recordFailure("c", '"x"');
+      recordFailure("c", '"y"');
+      expect(getErrorMessage()).toBe('Line 1, col 3: expected "x" or "y"');
+    });
+
+    it("formats three+ expectations with Oxford comma", () => {
+      setInputStr("abc");
+      recordFailure("c", '"x"');
+      recordFailure("c", '"y"');
+      recordFailure("c", '"z"');
+      expect(getErrorMessage()).toBe(
+        'Line 1, col 3: expected "x", "y", or "z"'
+      );
+    });
+
+    it("computes correct line and column for multiline input", () => {
+      const input = "line1\nline2\nline3";
+      setInputStr(input);
+      // "e2\nline3" has length 8, so pos = 17 - 8 = 9
+      // line 2 starts at offset 6, so column = 9 - 6 = 3, 1-based = 4
+      recordFailure("e2\nline3", '"x"');
+      expect(getErrorMessage()).toBe('Line 2, col 4: expected "x"');
+    });
+  });
+
+  describe("label", () => {
+    it("records only the label, suppressing inner recordings", () => {
+      const input = "xyz";
+      setInputStr(input);
+      const p = label("a digit", char("0"));
+      p(input);
+      const failure = getRightmostFailure();
+      expect(failure).toEqual({
+        pos: 0,
+        expected: ["a digit"],
+      });
+    });
+
+    it("does not affect state on success", () => {
+      const input = "0xyz";
+      setInputStr(input);
+      const p = label("a digit", char("0"));
+      const result = p(input);
+      expect(result.success).toBe(true);
+      expect(getRightmostFailure()).toBeNull();
+    });
+  });
+
+  describe("integration with or", () => {
+    it("accumulates labels from or alternatives", () => {
+      const input = "!";
+      setInputStr(input);
+      const p = or(digit, letter);
+      p(input);
+      const failure = getRightmostFailure();
+      expect(failure).toEqual({
+        pos: 0,
+        expected: ["a digit", "a letter"],
+      });
+    });
+
+    it("produces a clean error message from or", () => {
+      const input = "!";
+      setInputStr(input);
+      const p = or(digit, letter);
+      p(input);
+      expect(getErrorMessage()).toBe(
+        "Line 1, col 1: expected a digit or a letter"
+      );
+    });
+
+    it("reports the rightmost failure across or alternatives", () => {
+      // str checks the full string at once, so both fail at position 0
+      // to test rightmost, use seq-based parsers where one gets further
+      const input = "ac";
+      setInputStr(input);
+      const p = or(str("ab"), str("xy"));
+      p(input);
+      expect(getErrorMessage()).toBe(
+        'Line 1, col 1: expected "ab" or "xy"'
+      );
+    });
+  });
+
+  describe("built-in labeled parsers", () => {
+    it("digit records 'a digit'", () => {
+      setInputStr("x");
+      digit("x");
+      expect(getRightmostFailure()?.expected).toEqual(["a digit"]);
+    });
+
+    it("letter records 'a letter'", () => {
+      setInputStr("1");
+      letter("1");
+      expect(getRightmostFailure()?.expected).toEqual(["a letter"]);
+    });
+  });
+});

--- a/tests/rightmostFailure.test.ts
+++ b/tests/rightmostFailure.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, beforeEach } from "vitest";
+import { setInputStr } from "@/lib/trace.js";
 import {
-  setInputStr,
   recordFailure,
   getRightmostFailure,
   getErrorMessage,
-} from "@/lib/trace.js";
+} from "@/lib/rightmostFailure.js";
 import { char, str, digit, letter, or, label } from "@/lib/index.js";
 
 describe("rightmost failure tracking", () => {


### PR DESCRIPTION
## Summary

- Adds rightmost-failure tracking (inspired by Ohm.js) so parse errors report **what was expected** at the **furthest position** the parser reached
- Adds `label(name, parser)` combinator for attaching friendly expectation names that suppress inner noise (e.g., `label("a digit", oneOf("0123456789"))` reports `"a digit"` instead of `"one of \"0123456789\""`)
- Adds `recordFailure()`, `getRightmostFailure()`, and `getErrorMessage()` to `trace.ts`
- `setInputStr()` auto-resets failure state, so no extra setup needed
- Built-in parsers (`digit`, `space`, `letter`, `alphanum`, `word`, `num`, `quote`) wrapped with `label` for clean messages out of the box
- `getErrorMessage()` formats with Oxford comma: `expected a digit, a letter, or "("` 

## Test plan

- [x] 19 new tests covering `recordFailure`, `getErrorMessage` formatting, `label` suppression, `or` accumulation, and built-in labeled parsers
- [x] All 255 tests pass (236 existing + 19 new)
- [x] Build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)