### PR TITLE
Markdown example: nested inline content

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 ## Unreleased
 - Markdown example: inline emphasis, strikethrough, and inline-link nodes
   now carry `InlineMarkdown[]` content instead of `string`, so nested
-  inlines like `**[link](u)**` or `*foo `code` bar*` round-trip through
+  inlines like ``**[link](u)**`` or ``*foo `code` bar*`` round-trip through
   the AST. A new `inlineSeqUntil(stop)` helper handles node-level
   recursion via `lazy`; code spans, autolinks, and image alt-text stay
   string-typed (they aren't nestable per CommonMark). `]` is added to the

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,12 @@
 ## Unreleased
+- Markdown example: inline emphasis, strikethrough, and inline-link nodes
+  now carry `InlineMarkdown[]` content instead of `string`, so nested
+  inlines like `**[link](u)**` or `*foo `code` bar*` round-trip through
+  the AST. A new `inlineSeqUntil(stop)` helper handles node-level
+  recursion via `lazy`; code spans, autolinks, and image alt-text stay
+  string-typed (they aren't nestable per CommonMark). `]` is added to the
+  inline-text stop set and literal-char fallback so stray `]` outside a
+  link still renders.
 - Markdown example: rewritten as a small package under `tests/examples/markdown/`
   (`types.ts`, `inline.ts`, `blocks.ts`, `references.ts`, `index.ts`) and brought
   to near-CommonMark coverage, all built from Tarsec combinators:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ parser("hello there"); // failure
 - [Pretty error messages](/tutorials/pretty-errors.md)
 
 ## Examples
-- [A CommonMark-ish markdown parser](/tests/examples/markdown) — headings (ATX + setext), fenced and indented code blocks, multi-line / nested block quotes, ordered / unordered / nested lists, pipe tables with alignment, horizontal rules, HTML passthrough, VitePress-style YAML frontmatter, plus inline bold/italic (`*` and `_`), combined `***bold-italic***`, strikethrough, escapes, autolinks, hard line breaks, images, and reference-style links / footnotes resolved in a post-parse pass. Inline emphasis, strike, and link content all nest, so `**[link](u)**` and `*a `code` b*` round-trip into the AST.
+- [A CommonMark-ish markdown parser](/tests/examples/markdown) — headings (ATX + setext), fenced and indented code blocks, multi-line / nested block quotes, ordered / unordered / nested lists, pipe tables with alignment, horizontal rules, HTML passthrough, VitePress-style YAML frontmatter, plus inline bold/italic (`*` and `_`), combined `***bold-italic***`, strikethrough, escapes, autolinks, hard line breaks, images, and reference-style links / footnotes resolved in a post-parse pass. Inline emphasis, strike, and link content all nest, so ``**[link](u)**`` and ``*a `code` b*`` round-trip into the AST.
 
 Read more about [use cases for tarsec](/tutorials/use-case.md).
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ parser("hello there"); // failure
 - [Pretty error messages](/tutorials/pretty-errors.md)
 
 ## Examples
-- [A CommonMark-ish markdown parser](/tests/examples/markdown) — headings (ATX + setext), fenced and indented code blocks, multi-line / nested block quotes, ordered / unordered / nested lists, pipe tables with alignment, horizontal rules, HTML passthrough, VitePress-style YAML frontmatter, plus inline bold/italic (`*` and `_`), combined `***bold-italic***`, strikethrough, escapes, autolinks, hard line breaks, images, and reference-style links / footnotes resolved in a post-parse pass.
+- [A CommonMark-ish markdown parser](/tests/examples/markdown) — headings (ATX + setext), fenced and indented code blocks, multi-line / nested block quotes, ordered / unordered / nested lists, pipe tables with alignment, horizontal rules, HTML passthrough, VitePress-style YAML frontmatter, plus inline bold/italic (`*` and `_`), combined `***bold-italic***`, strikethrough, escapes, autolinks, hard line breaks, images, and reference-style links / footnotes resolved in a post-parse pass. Inline emphasis, strike, and link content all nest, so `**[link](u)**` and `*a `code` b*` round-trip into the AST.
 
 Read more about [use cases for tarsec](/tutorials/use-case.md).
 

--- a/tests/examples/markdown.test.ts
+++ b/tests/examples/markdown.test.ts
@@ -104,7 +104,7 @@ describe("paragraphParser", () => {
         },
         {
           type: "inline-link",
-          content: "nearley",
+          content: [{ type: "inline-text", content: "nearley" }],
           url: "https://nearley.js.org/",
         },
         {
@@ -113,7 +113,7 @@ describe("paragraphParser", () => {
         },
         {
           type: "inline-link",
-          content: "yacc",
+          content: [{ type: "inline-text", content: "yacc" }],
           url: "https://silcnitc.github.io/yacc.html",
         },
         {
@@ -176,7 +176,7 @@ describe("inlineLinkParser", () => {
     const input = "[Link Text](https://example.com)";
     const expected = {
       type: "inline-link",
-      content: "Link Text",
+      content: [{ type: "inline-text", content: "Link Text" }],
       url: "https://example.com",
     };
     expect(inlineLinkParser(input)).toEqual(success(expected, ""));
@@ -236,7 +236,7 @@ describe("inlineMarkdownParser", () => {
     const expected = success(
       {
         type: "inline-link",
-        content: "Link Text",
+        content: [{ type: "inline-text", content: "Link Text" }],
         url: "https://example.com",
       },
       ""

--- a/tests/examples/markdown.test.ts
+++ b/tests/examples/markdown.test.ts
@@ -165,7 +165,7 @@ describe("inlineItalicParser", () => {
     const input = "*This is italic text*";
     const expected = {
       type: "inline-italic",
-      content: "This is italic text",
+      content: [{ type: "inline-text", content: "This is italic text" }],
     };
     expect(inlineItalicParser(input)).toEqual(success(expected, ""));
   });
@@ -224,7 +224,7 @@ describe("inlineMarkdownParser", () => {
     const expected = success(
       {
         type: "inline-italic",
-        content: "This is italic text",
+        content: [{ type: "inline-text", content: "This is italic text" }],
       },
       ""
     );

--- a/tests/examples/markdown.test.ts
+++ b/tests/examples/markdown.test.ts
@@ -154,7 +154,7 @@ describe("inlineBoldParser", () => {
     const input = "**This is bold text**";
     const expected = {
       type: "inline-bold",
-      content: "This is bold text",
+      content: [{ type: "inline-text", content: "This is bold text" }],
     };
     expect(inlineBoldParser(input)).toEqual(success(expected, ""));
   });
@@ -212,7 +212,7 @@ describe("inlineMarkdownParser", () => {
     const expected = success(
       {
         type: "inline-bold",
-        content: "This is bold text",
+        content: [{ type: "inline-text", content: "This is bold text" }],
       },
       ""
     );

--- a/tests/examples/markdown/blocks.test.ts
+++ b/tests/examples/markdown/blocks.test.ts
@@ -67,7 +67,10 @@ describe("ATX heading inline content", () => {
     if (res.success) {
       expect(res.result.content).toEqual([
         { type: "inline-text", content: "hello " },
-        { type: "inline-bold", content: "world" },
+        {
+          type: "inline-bold",
+          content: [{ type: "inline-text", content: "world" }],
+        },
       ]);
     }
   });

--- a/tests/examples/markdown/index.test.ts
+++ b/tests/examples/markdown/index.test.ts
@@ -72,7 +72,7 @@ describe("markdownParser integration", () => {
       expect(paragraph.type).toBe("paragraph");
       expect(paragraph.content[0]).toEqual({
         type: "inline-link",
-        content: "hi",
+        content: [{ type: "inline-text", content: "hi" }],
         url: "https://example.com",
       });
     }

--- a/tests/examples/markdown/index.test.ts
+++ b/tests/examples/markdown/index.test.ts
@@ -77,4 +77,37 @@ describe("markdownParser integration", () => {
       });
     }
   });
+
+  it("nested inlines round-trip through markdownParser", () => {
+    const res = markdownParser(
+      "Try **[the docs](https://x.dev)** or *`run --help`* now."
+    );
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.result).toEqual([
+        {
+          type: "paragraph",
+          content: [
+            { type: "inline-text", content: "Try " },
+            {
+              type: "inline-bold",
+              content: [
+                {
+                  type: "inline-link",
+                  url: "https://x.dev",
+                  content: [{ type: "inline-text", content: "the docs" }],
+                },
+              ],
+            },
+            { type: "inline-text", content: " or " },
+            {
+              type: "inline-italic",
+              content: [{ type: "inline-code", content: "run --help" }],
+            },
+            { type: "inline-text", content: " now." },
+          ],
+        },
+      ]);
+    }
+  });
 });

--- a/tests/examples/markdown/inline.test.ts
+++ b/tests/examples/markdown/inline.test.ts
@@ -261,7 +261,7 @@ describe("autolinks", () => {
     if (res.success)
       expect(res.result).toEqual({
         type: "inline-link",
-        content: "https://example.com",
+        content: [{ type: "inline-text", content: "https://example.com" }],
         url: "https://example.com",
       });
   });
@@ -278,7 +278,7 @@ describe("autolinks", () => {
     if (res.success)
       expect(res.result).toEqual({
         type: "inline-link",
-        content: "a@b.com",
+        content: [{ type: "inline-text", content: "a@b.com" }],
         url: "mailto:a@b.com",
       });
   });
@@ -314,6 +314,26 @@ describe("strikethrough", () => {
             content: [{ type: "inline-text", content: "bold" }],
           },
           { type: "inline-text", content: " gone" },
+        ],
+      });
+    }
+  });
+
+  it("inline-link content carries nested inline nodes", () => {
+    const res = inlineMarkdownParser("[a **b** `c`](u)");
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.result).toEqual({
+        type: "inline-link",
+        url: "u",
+        content: [
+          { type: "inline-text", content: "a " },
+          {
+            type: "inline-bold",
+            content: [{ type: "inline-text", content: "b" }],
+          },
+          { type: "inline-text", content: " " },
+          { type: "inline-code", content: "c" },
         ],
       });
     }

--- a/tests/examples/markdown/inline.test.ts
+++ b/tests/examples/markdown/inline.test.ts
@@ -310,14 +310,20 @@ describe("bold-italic combined", () => {
     const res = inlineMarkdownParser("***hey***");
     expect(res.success).toBe(true);
     if (res.success)
-      expect(res.result).toEqual({ type: "inline-bold-italic", content: "hey" });
+      expect(res.result).toEqual({
+        type: "inline-bold-italic",
+        content: [{ type: "inline-text", content: "hey" }],
+      });
   });
 
   it("parses ___x___ as bold-italic", () => {
     const res = inlineMarkdownParser("___hey___");
     expect(res.success).toBe(true);
     if (res.success)
-      expect(res.result).toEqual({ type: "inline-bold-italic", content: "hey" });
+      expect(res.result).toEqual({
+        type: "inline-bold-italic",
+        content: [{ type: "inline-text", content: "hey" }],
+      });
   });
 
   it("does not greedily eat ***x*** as bold of '*x*'", () => {

--- a/tests/examples/markdown/inline.test.ts
+++ b/tests/examples/markdown/inline.test.ts
@@ -67,9 +67,26 @@ describe("bold vs italic ordering", () => {
         type: "inline-bold",
         content: [
           { type: "inline-text", content: "a " },
-          { type: "inline-italic", content: "b" },
+          {
+            type: "inline-italic",
+            content: [{ type: "inline-text", content: "b" }],
+          },
           { type: "inline-text", content: " " },
           { type: "inline-code", content: "c" },
+        ],
+      });
+    }
+  });
+
+  it("italic content carries nested inline nodes (code)", () => {
+    const res = inlineMarkdownParser("*see `here`*");
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.result).toEqual({
+        type: "inline-italic",
+        content: [
+          { type: "inline-text", content: "see " },
+          { type: "inline-code", content: "here" },
         ],
       });
     }
@@ -141,7 +158,10 @@ describe("underscore emphasis", () => {
     const res = inlineItalicUnderscoreParser("_x_");
     expect(res.success).toBe(true);
     if (res.success)
-      expect(res.result).toEqual({ type: "inline-italic", content: "x" });
+      expect(res.result).toEqual({
+        type: "inline-italic",
+        content: [{ type: "inline-text", content: "x" }],
+      });
   });
 
   it("parses __x__ as bold", () => {

--- a/tests/examples/markdown/inline.test.ts
+++ b/tests/examples/markdown/inline.test.ts
@@ -296,7 +296,27 @@ describe("strikethrough", () => {
     const res = inlineMarkdownParser("~~gone~~");
     expect(res.success).toBe(true);
     if (res.success)
-      expect(res.result).toEqual({ type: "inline-strike", content: "gone" });
+      expect(res.result).toEqual({
+        type: "inline-strike",
+        content: [{ type: "inline-text", content: "gone" }],
+      });
+  });
+
+  it("strike content carries nested inline nodes", () => {
+    const res = inlineMarkdownParser("~~**bold** gone~~");
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.result).toEqual({
+        type: "inline-strike",
+        content: [
+          {
+            type: "inline-bold",
+            content: [{ type: "inline-text", content: "bold" }],
+          },
+          { type: "inline-text", content: " gone" },
+        ],
+      });
+    }
   });
 
   it("falls back to literal ~ when not paired", () => {

--- a/tests/examples/markdown/inline.test.ts
+++ b/tests/examples/markdown/inline.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { success } from "@/lib/types";
+import { str } from "@/lib/parsers";
 import {
   inlineMarkdownParser,
   inlineItalicParser,
@@ -7,7 +8,44 @@ import {
   inlineEscapeParser,
   inlineItalicUnderscoreParser,
   inlineBoldUnderscoreParser,
+  inlineSeqUntil,
 } from "./inline";
+
+describe("inlineSeqUntil", () => {
+  it("collects inline nodes up to (but not including) the stop", () => {
+    const p = inlineSeqUntil(str("**"));
+    const res = p("foo bar**");
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.rest).toBe("**");
+      expect(res.result).toEqual([
+        { type: "inline-text", content: "foo bar" },
+      ]);
+    }
+  });
+
+  it("returns an empty array when the stop matches immediately", () => {
+    const p = inlineSeqUntil(str("**"));
+    const res = p("**rest");
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.result).toEqual([]);
+      expect(res.rest).toBe("**rest");
+    }
+  });
+
+  it("collects through to the end of input when the stop never matches", () => {
+    const p = inlineSeqUntil(str("**"));
+    const res = p("foo");
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.rest).toBe("");
+      expect(res.result).toEqual([
+        { type: "inline-text", content: "foo" },
+      ]);
+    }
+  });
+});
 
 describe("bold vs italic ordering", () => {
   it("parses ** as bold even when * could match first", () => {

--- a/tests/examples/markdown/inline.test.ts
+++ b/tests/examples/markdown/inline.test.ts
@@ -52,7 +52,26 @@ describe("bold vs italic ordering", () => {
     const res = inlineMarkdownParser("**hi**");
     expect(res.success).toBe(true);
     if (res.success) {
-      expect(res.result).toEqual({ type: "inline-bold", content: "hi" });
+      expect(res.result).toEqual({
+        type: "inline-bold",
+        content: [{ type: "inline-text", content: "hi" }],
+      });
+    }
+  });
+
+  it("bold content carries nested inline nodes (italic, code)", () => {
+    const res = inlineMarkdownParser("**a *b* `c`**");
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.result).toEqual({
+        type: "inline-bold",
+        content: [
+          { type: "inline-text", content: "a " },
+          { type: "inline-italic", content: "b" },
+          { type: "inline-text", content: " " },
+          { type: "inline-code", content: "c" },
+        ],
+      });
     }
   });
 
@@ -129,7 +148,10 @@ describe("underscore emphasis", () => {
     const res = inlineBoldUnderscoreParser("__x__");
     expect(res.success).toBe(true);
     if (res.success)
-      expect(res.result).toEqual({ type: "inline-bold", content: "x" });
+      expect(res.result).toEqual({
+        type: "inline-bold",
+        content: [{ type: "inline-text", content: "x" }],
+      });
   });
 
   it("dispatches _x_ via inlineMarkdownParser", () => {

--- a/tests/examples/markdown/inline.ts
+++ b/tests/examples/markdown/inline.ts
@@ -45,11 +45,32 @@ export const inlineTextParser: Parser<InlineText> = map(
   (content) => ({ type: "inline-text", content })
 );
 
-export const inlineBoldParser: Parser<InlineBold> = seqC(
-  set("type", "inline-bold"),
-  str("**"),
-  capture(manyTillStr("**"), "content"),
-  str("**")
+/**
+ * Run `inlineMarkdownParser` repeatedly until `stop` would match at the
+ * current position. The `stop` parser is a lookahead — it is *not* consumed.
+ * Returns the list of inline nodes collected before `stop`.
+ *
+ * Used by every delimited inline parser (bold, italic, strike, link, …) so
+ * that the content between delimiters is a sequence of inline nodes rather
+ * than a flat string.
+ */
+export const inlineSeqUntil = (
+  stop: Parser<unknown>
+): Parser<InlineMarkdown[]> =>
+  many(
+    map(
+      seqC(not(stop), capture(lazy(() => inlineMarkdownParser), "node")),
+      ({ node }) => node as InlineMarkdown
+    )
+  );
+
+export const inlineBoldParser: Parser<InlineBold> = map(
+  seqC(
+    str("**"),
+    capture(inlineSeqUntil(str("**")), "content"),
+    str("**")
+  ),
+  ({ content }) => ({ type: "inline-bold" as const, content: content as InlineMarkdown[] })
 );
 
 export const inlineItalicParser: Parser<InlineItalic> = seqC(
@@ -98,12 +119,14 @@ export const inlineBoldItalicParser: Parser<InlineBoldItalic> = or(
   )
 );
 
-export const inlineBoldUnderscoreParser: Parser<InlineBold> = seqC(
-  set("type", "inline-bold"),
-  str("__"),
-  capture(manyTillStr("__"), "content"),
-  str("__"),
-  not(alphanum)
+export const inlineBoldUnderscoreParser: Parser<InlineBold> = map(
+  seqC(
+    str("__"),
+    capture(inlineSeqUntil(str("__")), "content"),
+    str("__"),
+    not(alphanum)
+  ),
+  ({ content }) => ({ type: "inline-bold" as const, content: content as InlineMarkdown[] })
 );
 
 export const inlineItalicUnderscoreParser: Parser<InlineItalic> = seqC(
@@ -246,22 +269,3 @@ export const inlineMarkdownParser: Parser<InlineMarkdown> = or(
   inlineTextParser,
   inlineLiteralCharParser
 );
-
-/**
- * Run `inlineMarkdownParser` repeatedly until `stop` would match at the
- * current position. The `stop` parser is a lookahead — it is *not* consumed.
- * Returns the list of inline nodes collected before `stop`.
- *
- * Used by every delimited inline parser (bold, italic, strike, link, …) so
- * that the content between delimiters is a sequence of inline nodes rather
- * than a flat string.
- */
-export const inlineSeqUntil = (
-  stop: Parser<unknown>
-): Parser<InlineMarkdown[]> =>
-  many(
-    map(
-      seqC(not(stop), capture(lazy(() => inlineMarkdownParser), "node")),
-      ({ node }) => node as InlineMarkdown
-    )
-  );

--- a/tests/examples/markdown/inline.ts
+++ b/tests/examples/markdown/inline.ts
@@ -34,9 +34,10 @@ import { optional, between } from "@/lib/combinators";
 
 // Stop inline-text at any single delimiter char OR at a hard-break sequence
 // ("  \n"+). Using many1Till with an `or` of delimiters makes the stop set
-// composable rather than embedded inside a regex.
+// composable rather than embedded inside a regex. `]` is included so that
+// inline-text inside a link-text (`[...]`) terminates at the closing `]`.
 const inlineTextStop: Parser<unknown> = or(
-  oneOf("*_`[!<~\\\n"),
+  oneOf("*_`[]!<~\\\n"),
   str("  ")
 );
 
@@ -83,13 +84,19 @@ export const inlineItalicParser: Parser<InlineItalic> = map(
   ({ content }) => ({ type: "inline-italic" as const, content: content as InlineMarkdown[] })
 );
 
-export const inlineLinkParser: Parser<InlineLink> = seqC(
-  set("type", "inline-link"),
-  str("["),
-  capture(iManyTillStr("]("), "content"),
-  str("]("),
-  capture(iManyTillStr(")"), "url"),
-  str(")")
+export const inlineLinkParser: Parser<InlineLink> = map(
+  seqC(
+    char("["),
+    capture(inlineSeqUntil(char("]")), "content"),
+    str("]("),
+    capture(iManyTillStr(")"), "url"),
+    str(")")
+  ),
+  ({ content, url }) => ({
+    type: "inline-link" as const,
+    content: content as InlineMarkdown[],
+    url,
+  })
 );
 
 export const inlineCodeParser: Parser<InlineCode> = seqC(
@@ -170,16 +177,21 @@ const emailBody = map(
   (parts) => parts.join("")
 );
 
+// Wrap a literal string as the single-text content array used by InlineLink.
+const asTextContent = (s: string): InlineMarkdown[] => [
+  { type: "inline-text", content: s },
+];
+
 export const urlAutolinkParser: Parser<InlineLink> = map(
   seqC(char("<"), capture(urlBody, "url"), char(">")),
-  ({ url }) => ({ type: "inline-link" as const, content: url, url })
+  ({ url }) => ({ type: "inline-link" as const, content: asTextContent(url), url })
 );
 
 export const emailAutolinkParser: Parser<InlineLink> = map(
   seqC(char("<"), capture(emailBody, "email"), char(">")),
   ({ email }) => ({
     type: "inline-link" as const,
-    content: email,
+    content: asTextContent(email),
     url: `mailto:${email}`,
   })
 );
@@ -266,7 +278,7 @@ export const inlineStrikeParser: Parser<InlineStrike> = map(
  *  the paragraph. Matches one of the inline-text stop characters. */
 export const inlineLiteralCharParser: Parser<InlineText> = seqC(
   set("type", "inline-text"),
-  capture(oneOf("*_`[!<~\\"), "content")
+  capture(oneOf("*_`[]!<~\\"), "content")
 );
 
 export const inlineMarkdownParser: Parser<InlineMarkdown> = or(

--- a/tests/examples/markdown/inline.ts
+++ b/tests/examples/markdown/inline.ts
@@ -107,17 +107,27 @@ export const inlineEscapeParser: Parser<InlineText> = seqC(
 );
 
 export const inlineBoldItalicParser: Parser<InlineBoldItalic> = or(
-  seqC(
-    set("type", "inline-bold-italic"),
-    str("***"),
-    capture(manyTillStr("***"), "content"),
-    str("***")
+  map(
+    seqC(
+      str("***"),
+      capture(inlineSeqUntil(str("***")), "content"),
+      str("***")
+    ),
+    ({ content }) => ({
+      type: "inline-bold-italic" as const,
+      content: content as InlineMarkdown[],
+    })
   ),
-  seqC(
-    set("type", "inline-bold-italic"),
-    str("___"),
-    capture(manyTillStr("___"), "content"),
-    str("___")
+  map(
+    seqC(
+      str("___"),
+      capture(inlineSeqUntil(str("___")), "content"),
+      str("___")
+    ),
+    ({ content }) => ({
+      type: "inline-bold-italic" as const,
+      content: content as InlineMarkdown[],
+    })
   )
 );
 

--- a/tests/examples/markdown/inline.ts
+++ b/tests/examples/markdown/inline.ts
@@ -10,6 +10,7 @@ import {
   many1WithJoin,
   manyTillStr,
   iManyTillStr,
+  lazy,
 } from "@/lib/combinators";
 import { str, char, set, oneOf, alphanum, noneOf } from "@/lib/parsers";
 import { Parser } from "@/lib/types";
@@ -245,3 +246,22 @@ export const inlineMarkdownParser: Parser<InlineMarkdown> = or(
   inlineTextParser,
   inlineLiteralCharParser
 );
+
+/**
+ * Run `inlineMarkdownParser` repeatedly until `stop` would match at the
+ * current position. The `stop` parser is a lookahead — it is *not* consumed.
+ * Returns the list of inline nodes collected before `stop`.
+ *
+ * Used by every delimited inline parser (bold, italic, strike, link, …) so
+ * that the content between delimiters is a sequence of inline nodes rather
+ * than a flat string.
+ */
+export const inlineSeqUntil = (
+  stop: Parser<unknown>
+): Parser<InlineMarkdown[]> =>
+  many(
+    map(
+      seqC(not(stop), capture(lazy(() => inlineMarkdownParser), "node")),
+      ({ node }) => node as InlineMarkdown
+    )
+  );

--- a/tests/examples/markdown/inline.ts
+++ b/tests/examples/markdown/inline.ts
@@ -73,12 +73,14 @@ export const inlineBoldParser: Parser<InlineBold> = map(
   ({ content }) => ({ type: "inline-bold" as const, content: content as InlineMarkdown[] })
 );
 
-export const inlineItalicParser: Parser<InlineItalic> = seqC(
-  set("type", "inline-italic"),
-  not(str("**")),
-  char("*"),
-  capture(manyTillStr("*"), "content"),
-  char("*")
+export const inlineItalicParser: Parser<InlineItalic> = map(
+  seqC(
+    not(str("**")),
+    char("*"),
+    capture(inlineSeqUntil(char("*")), "content"),
+    char("*")
+  ),
+  ({ content }) => ({ type: "inline-italic" as const, content: content as InlineMarkdown[] })
 );
 
 export const inlineLinkParser: Parser<InlineLink> = seqC(
@@ -129,13 +131,15 @@ export const inlineBoldUnderscoreParser: Parser<InlineBold> = map(
   ({ content }) => ({ type: "inline-bold" as const, content: content as InlineMarkdown[] })
 );
 
-export const inlineItalicUnderscoreParser: Parser<InlineItalic> = seqC(
-  set("type", "inline-italic"),
-  not(str("__")),
-  char("_"),
-  capture(manyTillStr("_"), "content"),
-  char("_"),
-  not(alphanum)
+export const inlineItalicUnderscoreParser: Parser<InlineItalic> = map(
+  seqC(
+    not(str("__")),
+    char("_"),
+    capture(inlineSeqUntil(char("_")), "content"),
+    char("_"),
+    not(alphanum)
+  ),
+  ({ content }) => ({ type: "inline-italic" as const, content: content as InlineMarkdown[] })
 );
 
 // URL body inside <...>: http(s)://<non-space, non-< or >>

--- a/tests/examples/markdown/inline.ts
+++ b/tests/examples/markdown/inline.ts
@@ -249,11 +249,16 @@ export const hardBreakParser: Parser<InlineHardBreak> = map(
   () => ({ type: "inline-hard-break" as const })
 );
 
-export const inlineStrikeParser: Parser<InlineStrike> = seqC(
-  set("type", "inline-strike"),
-  str("~~"),
-  capture(manyTillStr("~~"), "content"),
-  str("~~")
+export const inlineStrikeParser: Parser<InlineStrike> = map(
+  seqC(
+    str("~~"),
+    capture(inlineSeqUntil(str("~~")), "content"),
+    str("~~")
+  ),
+  ({ content }) => ({
+    type: "inline-strike" as const,
+    content: content as InlineMarkdown[],
+  })
 );
 
 /** Last-resort: consume a single delimiter char as literal text so unmatched

--- a/tests/examples/markdown/references.test.ts
+++ b/tests/examples/markdown/references.test.ts
@@ -59,7 +59,13 @@ describe("resolveReferences", () => {
     expect(resolveReferences(ast)).toEqual([
       {
         type: "paragraph",
-        content: [{ type: "inline-link", content: "hi", url: "https://x" }],
+        content: [
+          {
+            type: "inline-link",
+            content: [{ type: "inline-text", content: "hi" }],
+            url: "https://x",
+          },
+        ],
       },
     ]);
   });

--- a/tests/examples/markdown/references.ts
+++ b/tests/examples/markdown/references.ts
@@ -75,7 +75,11 @@ export function resolveReferences(ast: unknown[]): unknown[] {
     if (obj.type === "inline-ref-link") {
       const def = linkDefs.get(String(obj.id).toLowerCase());
       if (def) {
-        return { type: "inline-link", content: obj.text, url: def.url };
+        return {
+          type: "inline-link",
+          content: [{ type: "inline-text", content: obj.text }],
+          url: def.url,
+        };
       }
       return { type: "inline-text", content: `[${obj.text}]` };
     }

--- a/tests/examples/markdown/references.ts
+++ b/tests/examples/markdown/references.ts
@@ -77,7 +77,7 @@ export function resolveReferences(ast: unknown[]): unknown[] {
       if (def) {
         return {
           type: "inline-link",
-          content: [{ type: "inline-text", content: obj.text }],
+          content: [{ type: "inline-text", content: String(obj.text) }],
           url: def.url,
         };
       }

--- a/tests/examples/markdown/types.ts
+++ b/tests/examples/markdown/types.ts
@@ -21,7 +21,7 @@ export type InlineText = {
 
 export type InlineBold = {
   type: "inline-bold";
-  content: string;
+  content: InlineMarkdown[];
 };
 
 export type InlineItalic = {

--- a/tests/examples/markdown/types.ts
+++ b/tests/examples/markdown/types.ts
@@ -26,7 +26,7 @@ export type InlineBold = {
 
 export type InlineItalic = {
   type: "inline-italic";
-  content: string;
+  content: InlineMarkdown[];
 };
 
 export type InlineBoldItalic = {

--- a/tests/examples/markdown/types.ts
+++ b/tests/examples/markdown/types.ts
@@ -36,7 +36,7 @@ export type InlineBoldItalic = {
 
 export type InlineStrike = {
   type: "inline-strike";
-  content: string;
+  content: InlineMarkdown[];
 };
 
 export type InlineHardBreak = {

--- a/tests/examples/markdown/types.ts
+++ b/tests/examples/markdown/types.ts
@@ -45,7 +45,7 @@ export type InlineHardBreak = {
 
 export type InlineLink = {
   type: "inline-link";
-  content: string;
+  content: InlineMarkdown[];
   url: string;
 };
 

--- a/tests/examples/markdown/types.ts
+++ b/tests/examples/markdown/types.ts
@@ -31,7 +31,7 @@ export type InlineItalic = {
 
 export type InlineBoldItalic = {
   type: "inline-bold-italic";
-  content: string;
+  content: InlineMarkdown[];
 };
 
 export type InlineStrike = {


### PR DESCRIPTION
Implements the [nested-inlines plan](docs/superpowers/plans/2026-05-28-markdown-nested-inlines.md). After this PR, every delimited inline parser can carry other inline nodes as content, so real-world snippets like \`**[link](u)**\`, \`*foo \`code\` bar*\`, and \`[a **b** \`c\`](u)\` round-trip into the AST instead of flattening to text.

## What changed

**AST**
- \`InlineBold.content\`, \`InlineItalic.content\`, \`InlineBoldItalic.content\`, \`InlineStrike.content\`, \`InlineLink.content\` are now \`InlineMarkdown[]\` (were \`string\`).
- \`InlineCode.content\`, \`Image.alt\`, autolink content, and \`InlineRefLink.text\` / \`InlineRefImage.alt\` stay \`string\` (not nestable per CommonMark).

**Parsers**
- New helper \`inlineSeqUntil(stop)\`: runs \`inlineMarkdownParser\` (via \`lazy\`) repeatedly until \`stop\` would match. \`stop\` is a lookahead — it isn't consumed.
- Every affected parser is rewritten as \`map(seqC(open, capture(inlineSeqUntil(close), 'content'), close), ({content}) => ...)\`.
- Autolinks wrap their URL/email string in a single \`inline-text\` node to fit the new shape.
- \`resolveReferences\` wraps resolved ref-link text the same way.
- \`]\` is added to the inline-text stop set and the literal-char fallback so stray \`]\` outside a link still renders, but inline-text inside link content terminates at the closing bracket.

**Out of scope** (deliberately, per the plan)
- Same-delimiter nesting (e.g., \`**foo **bar** baz**\`).
- CommonMark's full left/right-flanking emphasis algorithm.

## Tests

- 376 / 376 green (was 368).
- Every migrated parser has a nested-content test in \`inline.test.ts\` (bold-containing-italic-and-code, italic-containing-code, strike-containing-bold, link-containing-bold-and-code).
- New \`markdownParser\` smoke test in \`index.test.ts\` end-to-end asserts: \`Try **[the docs](https://x.dev)** or *\`run --help\`* now.\` parses into the fully-nested AST.
- All previously-string assertions across \`inline.test.ts\`, \`blocks.test.ts\`, \`references.test.ts\`, \`index.test.ts\`, and the legacy \`tests/examples/markdown.test.ts\` are updated to the new array shape (no weakened assertions).
- \`npm run test:tsc\` is clean (no new errors beyond the two pre-existing \`regex\` / \`vitest.globals\` ones on main).

## Commits

Each phase is its own commit so a bisect lands on one behavior:

1. \`feat(markdown): add inlineSeqUntil helper for node-level recursion\`
2. \`feat(markdown): bold (** and __) content is InlineMarkdown[]\`
3. \`feat(markdown): italic (* and _) content is InlineMarkdown[]\`
4. \`feat(markdown): bold-italic (*** and ___) content is InlineMarkdown[]\`
5. \`feat(markdown): strikethrough content is InlineMarkdown[]\`
6. \`feat(markdown): inline-link content is InlineMarkdown[]\`
7. \`test(markdown): smoke test for nested bold/italic/link/code through markdownParser\`