### PR TITLE
Markdown example: four CommonMark quick wins

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,18 @@
 ## Unreleased
+- Markdown example: closes four CommonMark gaps —
+  - ATX headings cap at level 6 (7+ `#` runs fall through to a paragraph)
+    and an optional trailing `#` run (preceded by a space) is stripped
+    from the heading content.
+  - Inline links and images accept an optional `"title"` (or `'title'`),
+    captured into a new optional `title?: string` field on `InlineLink`
+    and `Image`.
+  - Inline code spans support N-backtick fences — ``` ``a`b`` ``` parses
+    as content `` a`b ``, closing only on a run of *exactly* N backticks.
+    One leading and trailing space is stripped when both sides have one
+    (and the content isn't all whitespace).
+  - Paragraphs now consume soft-wrapped lines and emit an
+    `inline-soft-break` between them; blank lines still terminate the
+    paragraph and hard breaks (`"  \n"` / `"\\\n"`) still take precedence.
 - Markdown example: inline emphasis, strikethrough, and inline-link nodes
   now carry `InlineMarkdown[]` content instead of `string`, so nested
   inlines like ``**[link](u)**`` or ``*foo `code` bar*`` round-trip through

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ parser("hello there"); // failure
 - [Pretty error messages](/tutorials/pretty-errors.md)
 
 ## Examples
-- [A CommonMark-ish markdown parser](/tests/examples/markdown) — headings (ATX + setext), fenced and indented code blocks, multi-line / nested block quotes, ordered / unordered / nested lists, pipe tables with alignment, horizontal rules, HTML passthrough, VitePress-style YAML frontmatter, plus inline bold/italic (`*` and `_`), combined `***bold-italic***`, strikethrough, escapes, autolinks, hard line breaks, images, and reference-style links / footnotes resolved in a post-parse pass. Inline emphasis, strike, and link content all nest, so ``**[link](u)**`` and ``*a `code` b*`` round-trip into the AST.
+- [A CommonMark-ish markdown parser](/tests/examples/markdown) — headings (ATX 1–6 with optional trailing `#` stripping, plus setext), fenced and indented code blocks, multi-backtick inline code spans, multi-line / nested block quotes, ordered / unordered / nested lists, pipe tables with alignment, horizontal rules, HTML passthrough, VitePress-style YAML frontmatter, plus inline bold/italic (`*` and `_`), combined `***bold-italic***`, strikethrough, escapes, autolinks, hard *and* soft line breaks, images and links with optional `"title"`, and reference-style links / footnotes resolved in a post-parse pass. Paragraphs round-trip soft-wrapped lines through an `inline-soft-break` node. Inline emphasis, strike, and link content all nest, so ``**[link](u)**`` and ``*a `code` b*`` round-trip into the AST.
 
 Read more about [use cases for tarsec](/tutorials/use-case.md).
 

--- a/tests/examples/markdown/blocks.test.ts
+++ b/tests/examples/markdown/blocks.test.ts
@@ -74,6 +74,37 @@ describe("ATX heading level cap", () => {
   });
 });
 
+describe("ATX heading trailing '#' stripping", () => {
+  it("strips a trailing '#' run preceded by a space", () => {
+    const res = headingParser("## Heading ##");
+    expect(res.success).toBe(true);
+    if (res.success)
+      expect(res.result.content).toEqual([
+        { type: "inline-text", content: "Heading" },
+      ]);
+  });
+
+  it("does not strip when there's no separating space", () => {
+    const res = headingParser("## Heading##");
+    expect(res.success).toBe(true);
+    if (res.success)
+      expect(res.result.content).toEqual([
+        { type: "inline-text", content: "Heading##" },
+      ]);
+  });
+
+  it("strips trailing '#' followed by trailing spaces and newline", () => {
+    const res = headingParser("## Heading ###  \nrest");
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.result.content).toEqual([
+        { type: "inline-text", content: "Heading" },
+      ]);
+      expect(res.rest).toBe("rest");
+    }
+  });
+});
+
 describe("ATX heading inline content", () => {
   it("parses bold inside a heading", () => {
     const res = headingParser("# hello **world**");

--- a/tests/examples/markdown/blocks.test.ts
+++ b/tests/examples/markdown/blocks.test.ts
@@ -361,3 +361,42 @@ describe("paragraphParser blank-line termination", () => {
     }
   });
 });
+
+describe("paragraphParser soft-wrapping", () => {
+  it("joins soft-wrapped lines into one paragraph with inline-soft-break", () => {
+    const res = paragraphParser("one\ntwo\nthree");
+    expect(res.success).toBe(true);
+    if (res.success)
+      expect(res.result.content).toEqual([
+        { type: "inline-text", content: "one" },
+        { type: "inline-soft-break" },
+        { type: "inline-text", content: "two" },
+        { type: "inline-soft-break" },
+        { type: "inline-text", content: "three" },
+      ]);
+  });
+
+  it("terminates at a blank line, leaving the blank line in rest", () => {
+    const res = paragraphParser("one\ntwo\n\nthree");
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.result.content).toEqual([
+        { type: "inline-text", content: "one" },
+        { type: "inline-soft-break" },
+        { type: "inline-text", content: "two" },
+      ]);
+      expect(res.rest).toBe("\n\nthree");
+    }
+  });
+
+  it("does not insert a soft break before a hard break", () => {
+    const res = paragraphParser("one  \ntwo");
+    expect(res.success).toBe(true);
+    if (res.success)
+      expect(res.result.content).toEqual([
+        { type: "inline-text", content: "one" },
+        { type: "inline-hard-break" },
+        { type: "inline-text", content: "two" },
+      ]);
+  });
+});

--- a/tests/examples/markdown/blocks.test.ts
+++ b/tests/examples/markdown/blocks.test.ts
@@ -399,4 +399,27 @@ describe("paragraphParser soft-wrapping", () => {
         { type: "inline-text", content: "two" },
       ]);
   });
+
+  it.each<[string, string]>([
+    ["para\n# heading", "\n# heading"],
+    ["para\n> quote", "\n> quote"],
+    ["para\n- item", "\n- item"],
+    ["para\n1. item", "\n1. item"],
+    ["para\n```\ncode\n```", "\n```\ncode\n```"],
+    ["para\n---", "\n---"],
+    ["para\n| h | i |", "\n| h | i |"],
+    ["para\n<div>", "\n<div>"],
+  ])(
+    "stops a soft-wrapped paragraph before a block opener (%j)",
+    (input, expectedRest) => {
+      const res = paragraphParser(input);
+      expect(res.success).toBe(true);
+      if (res.success) {
+        expect(res.result.content).toEqual([
+          { type: "inline-text", content: "para" },
+        ]);
+        expect(res.rest).toBe(expectedRest);
+      }
+    }
+  );
 });

--- a/tests/examples/markdown/blocks.test.ts
+++ b/tests/examples/markdown/blocks.test.ts
@@ -60,6 +60,20 @@ describe("horizontalRuleParser", () => {
   });
 });
 
+describe("ATX heading level cap", () => {
+  it("parses heading levels 1–6", () => {
+    for (let n = 1; n <= 6; n++) {
+      const res = headingParser("#".repeat(n) + " Title");
+      expect(res.success).toBe(true);
+      if (res.success) expect(res.result.level).toBe(n);
+    }
+  });
+
+  it("rejects 7+ '#' as a heading", () => {
+    expect(headingParser("####### Title").success).toBe(false);
+  });
+});
+
 describe("ATX heading inline content", () => {
   it("parses bold inside a heading", () => {
     const res = headingParser("# hello **world**");

--- a/tests/examples/markdown/blocks.ts
+++ b/tests/examples/markdown/blocks.ts
@@ -5,6 +5,7 @@ import {
   optional,
   or,
   manyTillStr,
+  many1Till,
   exactly,
   iManyTillStr,
   many,
@@ -58,12 +59,38 @@ const atxMarker: Parser<number> = or(
   )
 );
 
-export const headingParser: Parser<Heading> = seqC(
-  set("type", "heading"),
-  capture(atxMarker, "level"),
-  spaces,
-  capture(many1(inlineMarkdownParser), "content"),
-  optional(char("\n"))
+/* An optional trailing run of `#`s on an ATX heading: at least one separating
+ * space, one or more `#`, optional trailing spaces, then end-of-line. */
+const trailingHashRun: Parser<unknown> = seqR(
+  many1(char(" ")),
+  many1(char("#")),
+  many(char(" ")),
+  or(char("\n"), eof)
+);
+
+/* The heading body — everything up to (but not including) either the line end
+ * or a trailing `#` run. We capture this as a raw string then re-parse it as
+ * inline markdown so the body shape matches ATX/setext headings. */
+const headingBody: Parser<string> = many1Till(or(char("\n"), trailingHashRun));
+
+export const headingParser: Parser<Heading> = map(
+  seqC(
+    capture(atxMarker, "level"),
+    spaces,
+    capture(headingBody, "body"),
+    optional(trailingHashRun),
+    optional(char("\n"))
+  ),
+  ({ level, body }) => {
+    const inner = many1(inlineMarkdownParser)(body as string);
+    return {
+      type: "heading" as const,
+      level: level as number,
+      content: inner.success
+        ? (inner.result as Heading["content"])
+        : [{ type: "inline-text" as const, content: body as string }],
+    };
+  }
 );
 
 export const codeBlockParser: Parser<CodeBlock> = seqC(

--- a/tests/examples/markdown/blocks.ts
+++ b/tests/examples/markdown/blocks.ts
@@ -43,7 +43,7 @@ import {
 } from "./types";
 import { digit, letter } from "@/lib/parsers";
 import { manyTill } from "@/lib/combinators";
-import { inlineMarkdownParser, imageParser } from "./inline";
+import { inlineMarkdownParser, imageParser, softBreakParser } from "./inline";
 export { imageParser } from "./inline";
 
 const languageChar = or(alphanum, oneOf("_+#.-"));
@@ -401,8 +401,15 @@ export const horizontalRuleParser: Parser<HorizontalRule> = or(
 // (`blankLine` is declared near `htmlBlockParser` above, since both need it at
 //  module-eval time.)
 
+/* A paragraph node: an inline node OR a soft line break (single `\n` that
+ * isn't the start of a blank line). Hard breaks ("  \n" / "\\\n") win over
+ * soft breaks because they're matched earlier inside `inlineMarkdownParser`'s
+ * `or`. */
 const paragraphInline: Parser<InlineMarkdown> = map(
-  seqC(not(blankLine), capture(inlineMarkdownParser, "node")),
+  seqC(
+    not(blankLine),
+    capture(or(softBreakParser, inlineMarkdownParser), "node")
+  ),
   ({ node }) => node as InlineMarkdown
 );
 

--- a/tests/examples/markdown/blocks.ts
+++ b/tests/examples/markdown/blocks.ts
@@ -5,7 +5,7 @@ import {
   optional,
   or,
   manyTillStr,
-  count,
+  exactly,
   iManyTillStr,
   many,
   many1,
@@ -48,9 +48,19 @@ export { imageParser } from "./inline";
 const languageChar = or(alphanum, oneOf("_+#.-"));
 const languageTag = many1WithJoin(languageChar);
 
+/* ATX heading marker: 1–6 consecutive `#`, not followed by another `#`.
+ * Try widest first so `###` doesn't parse as level 1 and leave `##` behind.
+ * `not(char("#"))` rejects 7+ `#` runs (they fall through to a paragraph). */
+const atxMarker: Parser<number> = or(
+  ...[6, 5, 4, 3, 2, 1].map(
+    (n): Parser<number> =>
+      map(seqR(exactly(n, char("#")), not(char("#"))), () => n)
+  )
+);
+
 export const headingParser: Parser<Heading> = seqC(
   set("type", "heading"),
-  capture(count(char("#")), "level"),
+  capture(atxMarker, "level"),
   spaces,
   capture(many1(inlineMarkdownParser), "content"),
   optional(char("\n"))

--- a/tests/examples/markdown/blocks.ts
+++ b/tests/examples/markdown/blocks.ts
@@ -401,14 +401,41 @@ export const horizontalRuleParser: Parser<HorizontalRule> = or(
 // (`blankLine` is declared near `htmlBlockParser` above, since both need it at
 //  module-eval time.)
 
+/* Block-level constructs that, if they would start at the *current* line
+ * position, must interrupt a soft-wrapped paragraph instead of being eaten
+ * as inline content. Setext is intentionally excluded — its underline is
+ * resolved by `setextHeadingParser` running ahead of `paragraphParser` in
+ * the top-level dispatch. */
+const blockInterrupt: Parser<unknown> = or(
+  // ATX heading (1–6 `#` then a space)
+  seqR(atxMarker, char(" ")),
+  // Block quote
+  char(">"),
+  // Fenced code block
+  str("```"),
+  // Horizontal rule (3+ of -, *, or _ with optional intervening spaces)
+  horizontalRuleParser,
+  // List marker (unordered or `<digits>.`) followed by a space
+  seqR(or(oneOf("-*+"), seqR(many1(digit), char("."))), char(" ")),
+  // Table row
+  char("|"),
+  // HTML block opener
+  seqR(char("<"), or(letter, oneOf("/!?")))
+);
+
 /* A paragraph node: an inline node OR a soft line break (single `\n` that
- * isn't the start of a blank line). Hard breaks ("  \n" / "\\\n") win over
- * soft breaks because they're matched earlier inside `inlineMarkdownParser`'s
- * `or`. */
+ * isn't the start of a blank line *and* doesn't precede a block opener).
+ * Hard breaks ("  \n" / "\\\n") win over soft breaks because they're
+ * matched earlier inside `inlineMarkdownParser`'s `or`. */
+const paragraphSoftBreak: Parser<InlineMarkdown> = map(
+  seqR(softBreakParser, not(blockInterrupt)),
+  () => ({ type: "inline-soft-break" as const })
+);
+
 const paragraphInline: Parser<InlineMarkdown> = map(
   seqC(
     not(blankLine),
-    capture(or(softBreakParser, inlineMarkdownParser), "node")
+    capture(or(paragraphSoftBreak, inlineMarkdownParser), "node")
   ),
   ({ node }) => node as InlineMarkdown
 );

--- a/tests/examples/markdown/inline.test.ts
+++ b/tests/examples/markdown/inline.test.ts
@@ -412,6 +412,18 @@ describe("inlineCodeParser multi-backtick", () => {
 });
 
 describe("inline-link titles", () => {
+  it("parses an inline link with an empty destination", () => {
+    const res = inlineLinkParser(`[a]()`);
+    expect(res.success).toBe(true);
+    if (res.success) expect(res.result.url).toBe("");
+  });
+
+  it("preserves an explicitly empty title", () => {
+    const res = inlineLinkParser(`[a](u "")`);
+    expect(res.success).toBe(true);
+    if (res.success) expect(res.result.title).toBe("");
+  });
+
   it("parses an inline link with a double-quoted title", () => {
     const res = inlineLinkParser(`[a](u "t")`);
     expect(res.success).toBe(true);
@@ -438,6 +450,18 @@ describe("inline-link titles", () => {
 });
 
 describe("image titles", () => {
+  it("parses an image with an empty destination", () => {
+    const res = imageParser(`![alt]()`);
+    expect(res.success).toBe(true);
+    if (res.success) expect(res.result.url).toBe("");
+  });
+
+  it("preserves an explicitly empty title", () => {
+    const res = imageParser(`![alt](u "")`);
+    expect(res.success).toBe(true);
+    if (res.success) expect(res.result.title).toBe("");
+  });
+
   it("parses an image with a double-quoted title", () => {
     const res = imageParser(`![alt](u "t")`);
     expect(res.success).toBe(true);

--- a/tests/examples/markdown/inline.test.ts
+++ b/tests/examples/markdown/inline.test.ts
@@ -11,6 +11,7 @@ import {
   inlineSeqUntil,
   inlineLinkParser,
   imageParser,
+  inlineCodeParser,
 } from "./inline";
 
 describe("inlineSeqUntil", () => {
@@ -371,6 +372,42 @@ describe("bold-italic combined", () => {
   it("does not greedily eat ***x*** as bold of '*x*'", () => {
     const res = inlineMarkdownParser("***hey***");
     if (res.success) expect(res.result.type).toBe("inline-bold-italic");
+  });
+});
+
+describe("inlineCodeParser multi-backtick", () => {
+  it("parses a single-backtick code span", () => {
+    expect(inlineCodeParser("`foo`")).toEqual(
+      success({ type: "inline-code", content: "foo" }, "")
+    );
+  });
+
+  it("parses a double-backtick code span containing a single backtick", () => {
+    expect(inlineCodeParser("``a`b``")).toEqual(
+      success({ type: "inline-code", content: "a`b" }, "")
+    );
+  });
+
+  it("strips one leading and trailing space when both sides have one", () => {
+    const res = inlineCodeParser("`` foo ``");
+    expect(res.success).toBe(true);
+    if (res.success) expect(res.result.content).toBe("foo");
+  });
+
+  it("does not strip when only one side has a space", () => {
+    const res = inlineCodeParser("` foo`");
+    expect(res.success).toBe(true);
+    if (res.success) expect(res.result.content).toBe(" foo");
+  });
+
+  it("preserves all-space content unchanged", () => {
+    const res = inlineCodeParser("`   `");
+    expect(res.success).toBe(true);
+    if (res.success) expect(res.result.content).toBe("   ");
+  });
+
+  it("fails on unmatched backtick runs", () => {
+    expect(inlineCodeParser("``foo`").success).toBe(false);
   });
 });
 

--- a/tests/examples/markdown/inline.test.ts
+++ b/tests/examples/markdown/inline.test.ts
@@ -9,6 +9,8 @@ import {
   inlineItalicUnderscoreParser,
   inlineBoldUnderscoreParser,
   inlineSeqUntil,
+  inlineLinkParser,
+  imageParser,
 } from "./inline";
 
 describe("inlineSeqUntil", () => {
@@ -369,6 +371,58 @@ describe("bold-italic combined", () => {
   it("does not greedily eat ***x*** as bold of '*x*'", () => {
     const res = inlineMarkdownParser("***hey***");
     if (res.success) expect(res.result.type).toBe("inline-bold-italic");
+  });
+});
+
+describe("inline-link titles", () => {
+  it("parses an inline link with a double-quoted title", () => {
+    const res = inlineLinkParser(`[a](u "t")`);
+    expect(res.success).toBe(true);
+    if (res.success)
+      expect(res.result).toEqual({
+        type: "inline-link",
+        content: [{ type: "inline-text", content: "a" }],
+        url: "u",
+        title: "t",
+      });
+  });
+
+  it("parses an inline link with a single-quoted title", () => {
+    const res = inlineLinkParser(`[a](u 't')`);
+    expect(res.success).toBe(true);
+    if (res.success) expect(res.result.title).toBe("t");
+  });
+
+  it("still parses a link without a title", () => {
+    const res = inlineLinkParser(`[a](u)`);
+    expect(res.success).toBe(true);
+    if (res.success) expect(res.result.title).toBeUndefined();
+  });
+});
+
+describe("image titles", () => {
+  it("parses an image with a double-quoted title", () => {
+    const res = imageParser(`![alt](u "t")`);
+    expect(res.success).toBe(true);
+    if (res.success)
+      expect(res.result).toEqual({
+        type: "image",
+        alt: "alt",
+        url: "u",
+        title: "t",
+      });
+  });
+
+  it("parses an image with a single-quoted title", () => {
+    const res = imageParser(`![alt](u 't')`);
+    expect(res.success).toBe(true);
+    if (res.success) expect(res.result.title).toBe("t");
+  });
+
+  it("still parses an image without a title", () => {
+    const res = imageParser(`![alt](u)`);
+    expect(res.success).toBe(true);
+    if (res.success) expect(res.result.title).toBeUndefined();
   });
 });
 

--- a/tests/examples/markdown/inline.ts
+++ b/tests/examples/markdown/inline.ts
@@ -26,6 +26,7 @@ import {
   InlineBoldItalic,
   InlineStrike,
   InlineHardBreak,
+  InlineSoftBreak,
   InlineLink,
   InlineCode,
   Image,
@@ -339,6 +340,14 @@ export const hardBreakParser: Parser<InlineHardBreak> = map(
     seqR(char("\\"), char("\n"))
   ),
   () => ({ type: "inline-hard-break" as const })
+);
+
+/** A single `\n` that is *not* part of a blank line (which would terminate the
+ *  enclosing paragraph). Hard breaks are matched earlier in `inlineMarkdownParser`'s
+ *  `or` so a "  \n" stays a hard break, never a soft one. */
+export const softBreakParser: Parser<InlineSoftBreak> = map(
+  seqR(char("\n"), not(char("\n"))),
+  () => ({ type: "inline-soft-break" as const })
 );
 
 export const inlineStrikeParser: Parser<InlineStrike> = map(

--- a/tests/examples/markdown/inline.ts
+++ b/tests/examples/markdown/inline.ts
@@ -9,12 +9,15 @@ import {
   many1,
   many1Till,
   many1WithJoin,
+  manyWithJoin,
   manyTillStr,
   iManyTillStr,
+  count,
+  exactly,
   lazy,
 } from "@/lib/combinators";
-import { str, char, set, oneOf, alphanum, noneOf } from "@/lib/parsers";
-import { Parser } from "@/lib/types";
+import { str, char, eof, set, oneOf, alphanum, noneOf } from "@/lib/parsers";
+import { Parser, success, failure } from "@/lib/types";
 import {
   InlineMarkdown,
   InlineText,
@@ -124,12 +127,56 @@ export const inlineLinkParser: Parser<InlineLink> = map(
   }
 );
 
-export const inlineCodeParser: Parser<InlineCode> = seqC(
-  set("type", "inline-code"),
-  str("`"),
-  capture(manyTillStr("`"), "content"),
-  str("`")
-);
+/* Multi-backtick code spans.
+ *
+ *   `foo`            → "foo"
+ *   ``a`b``          → "a`b"       (close on exactly N backticks)
+ *   `` foo ``        → "foo"       (strip one space on each side when both)
+ *   `   `            → "   "       (don't strip if content is all spaces)
+ *
+ * The opener is a run of N backticks; the closer is another run of *exactly*
+ * N backticks. Body atoms are either a single non-tick char or a tick run
+ * whose length is *not* N (so it can't be misread as the closer). The opener
+ * count threads into the closer via a small wrapper — every other piece is
+ * combinator-shaped. */
+const tickRun: Parser<number> = count(char("`"));
+
+const tickRunOf = (n: number): Parser<unknown> =>
+  seqR(exactly(n, char("`")), or(not(char("`")), eof));
+
+const codeBodyAtom = (n: number): Parser<string> =>
+  or(
+    noneOf("`"),
+    map(
+      seqR(not(tickRunOf(n)), many1(char("`"))),
+      (parts) => (parts[1] as string[]).join("")
+    )
+  );
+
+const codeBody = (n: number): Parser<string> =>
+  manyWithJoin(codeBodyAtom(n));
+
+const stripCodeSpan = (s: string): string =>
+  s.length >= 2 && s.startsWith(" ") && s.endsWith(" ") && s.trim().length > 0
+    ? s.slice(1, -1)
+    : s;
+
+export const inlineCodeParser: Parser<InlineCode> = (input) => {
+  const opened = tickRun(input);
+  if (!opened.success) return opened;
+  const n = opened.result;
+  const closed = map(
+    seqR(codeBody(n), tickRunOf(n)),
+    (parts) => stripCodeSpan(parts[0] as string)
+  )(opened.rest);
+  if (!closed.success) {
+    return failure("unmatched code span fence", input);
+  }
+  return success(
+    { type: "inline-code" as const, content: closed.result },
+    closed.rest
+  );
+};
 
 const ESCAPABLE = "\\`*_{}[]()#+-.!~<>|";
 export const inlineEscapeParser: Parser<InlineText> = seqC(

--- a/tests/examples/markdown/inline.ts
+++ b/tests/examples/markdown/inline.ts
@@ -2,6 +2,7 @@ import {
   seqC,
   seqR,
   capture,
+  captureCaptures,
   or,
   not,
   map,
@@ -90,21 +91,22 @@ export const inlineItalicParser: Parser<InlineItalic> = map(
 );
 
 /* URL + optional title used by both inline-link and inline-image parsers.
- * `urlToken` is whitespace- and `)`-terminated. `titleClause` is an optional
- * leading-space-separated `"..."` or `'...'`. Both are pure combinator-based
- * so the link/image parsers can share them without special casing. */
-const urlToken: Parser<string> = many1WithJoin(noneOf(" \t\n)"));
+ * `urlToken` is whitespace- and `)`-terminated. Empty destinations (`[a]()`)
+ * are allowed via `manyWithJoin` (zero-or-more). `titleClause` is an
+ * optional leading-space-separated `"..."` or `'...'`. Both are pure
+ * combinator-based so the link/image parsers can share them. */
+const urlToken: Parser<string> = manyWithJoin(noneOf(" \t\n)"));
 
-const dqTitle: Parser<string> = map(
-  seqC(char('"'), capture(manyTillStr('"'), "t"), char('"')),
-  ({ t }) => t
-);
-const sqTitle: Parser<string> = map(
-  seqC(char("'"), capture(manyTillStr("'"), "t"), char("'")),
-  ({ t }) => t
-);
 const titleClause: Parser<string> = map(
-  seqC(many1(char(" ")), capture(or(dqTitle, sqTitle), "title")),
+  seqC(
+    many1(char(" ")),
+    captureCaptures(
+      or(
+        seqC(char('"'), capture(manyTillStr('"'), "title"), char('"')),
+        seqC(char("'"), capture(manyTillStr("'"), "title"), char("'"))
+      )
+    )
+  ),
   ({ title }) => title
 );
 
@@ -123,7 +125,7 @@ export const inlineLinkParser: Parser<InlineLink> = map(
       content: content as InlineMarkdown[],
       url,
     };
-    if (title) link.title = title;
+    if (title != null) link.title = title;
     return link;
   }
 );
@@ -327,7 +329,7 @@ export const imageParser: Parser<Image> = map(
   ),
   ({ alt, url, title }) => {
     const img: Image = { type: "image", alt, url };
-    if (title) img.title = title;
+    if (title != null) img.title = title;
     return img;
   }
 );

--- a/tests/examples/markdown/inline.ts
+++ b/tests/examples/markdown/inline.ts
@@ -6,6 +6,7 @@ import {
   not,
   map,
   many,
+  many1,
   many1Till,
   many1WithJoin,
   manyTillStr,
@@ -84,19 +85,43 @@ export const inlineItalicParser: Parser<InlineItalic> = map(
   ({ content }) => ({ type: "inline-italic" as const, content: content as InlineMarkdown[] })
 );
 
+/* URL + optional title used by both inline-link and inline-image parsers.
+ * `urlToken` is whitespace- and `)`-terminated. `titleClause` is an optional
+ * leading-space-separated `"..."` or `'...'`. Both are pure combinator-based
+ * so the link/image parsers can share them without special casing. */
+const urlToken: Parser<string> = many1WithJoin(noneOf(" \t\n)"));
+
+const dqTitle: Parser<string> = map(
+  seqC(char('"'), capture(manyTillStr('"'), "t"), char('"')),
+  ({ t }) => t
+);
+const sqTitle: Parser<string> = map(
+  seqC(char("'"), capture(manyTillStr("'"), "t"), char("'")),
+  ({ t }) => t
+);
+const titleClause: Parser<string> = map(
+  seqC(many1(char(" ")), capture(or(dqTitle, sqTitle), "title")),
+  ({ title }) => title
+);
+
 export const inlineLinkParser: Parser<InlineLink> = map(
   seqC(
     char("["),
     capture(inlineSeqUntil(char("]")), "content"),
     str("]("),
-    capture(iManyTillStr(")"), "url"),
-    str(")")
+    capture(urlToken, "url"),
+    capture(optional(titleClause), "title"),
+    char(")")
   ),
-  ({ content, url }) => ({
-    type: "inline-link" as const,
-    content: content as InlineMarkdown[],
-    url,
-  })
+  ({ content, url, title }) => {
+    const link: InlineLink = {
+      type: "inline-link",
+      content: content as InlineMarkdown[],
+      url,
+    };
+    if (title) link.title = title;
+    return link;
+  }
 );
 
 export const inlineCodeParser: Parser<InlineCode> = seqC(
@@ -240,15 +265,23 @@ export const inlineRefImageParser: Parser<InlineRefImage> = map(
   })
 );
 
-/** An inline image: ![alt](url). Lives in `inline.ts` so it can participate
- *  in paragraph parsing without `blocks.ts` becoming a circular dep. */
-export const imageParser: Parser<Image> = seqC(
-  set("type", "image"),
-  str("!["),
-  capture(iManyTillStr("]("), "alt"),
-  str("]("),
-  capture(iManyTillStr(")"), "url"),
-  str(")")
+/** An inline image: ![alt](url) or ![alt](url "title"). Lives in `inline.ts`
+ *  so it can participate in paragraph parsing without `blocks.ts` becoming a
+ *  circular dep. */
+export const imageParser: Parser<Image> = map(
+  seqC(
+    str("!["),
+    capture(iManyTillStr("]("), "alt"),
+    str("]("),
+    capture(urlToken, "url"),
+    capture(optional(titleClause), "title"),
+    char(")")
+  ),
+  ({ alt, url, title }) => {
+    const img: Image = { type: "image", alt, url };
+    if (title) img.title = title;
+    return img;
+  }
 );
 
 export const hardBreakParser: Parser<InlineHardBreak> = map(

--- a/tests/examples/markdown/types.ts
+++ b/tests/examples/markdown/types.ts
@@ -2,6 +2,7 @@
 
 export type InlineMarkdown =
   | InlineText
+  | InlineSoftBreak
   | InlineBold
   | InlineItalic
   | InlineBoldItalic
@@ -41,6 +42,10 @@ export type InlineStrike = {
 
 export type InlineHardBreak = {
   type: "inline-hard-break";
+};
+
+export type InlineSoftBreak = {
+  type: "inline-soft-break";
 };
 
 export type InlineLink = {

--- a/tests/examples/markdown/types.ts
+++ b/tests/examples/markdown/types.ts
@@ -47,6 +47,7 @@ export type InlineLink = {
   type: "inline-link";
   content: InlineMarkdown[];
   url: string;
+  title?: string;
 };
 
 export type InlineCode = {
@@ -81,6 +82,7 @@ export type Image = {
   type: "image";
   url: string;
   alt: string;
+  title?: string;
 };
 
 export type InlineRefLink = {


### PR DESCRIPTION
Closes four small CommonMark gaps in the markdown example, one phase per commit. Each commit is its own red→green→commit TDD cycle.

## Changes

| # | Feature | Commit |
|---|---|---|
| 1 | ATX heading level capped at 6 (7+ `#` falls through to a paragraph) | 1a8392d |
| 2 | Optional trailing `#` run stripped from ATX headings | c6e246a |
| 3 | Optional `"title"` / `'title'` on inline links and images | dbd6489 |
| 4 | Multi-backtick code spans with proper space stripping | e5d1585 |
| 5 | Soft-wrapped paragraphs with `inline-soft-break` | 1659d4f |
| 6 | README + CHANGELOG | 61e6b10 |

## AST changes (additive only)
- `InlineMarkdown` union gains `InlineSoftBreak = { type: "inline-soft-break" }`.
- `InlineLink` and `Image` gain optional `title?: string`.

## Design notes
- **ATX heading marker** is now `or(...[6,5,4,3,2,1].map(n => seqR(exactly(n, char("#")), not(char("#")))))` — widest first, with a trailing `not(char("#"))` to reject 7+ runs.
- **Trailing `#` stripping** captures the body via `many1Till(or(\n, trailingHashRun))` then re-parses it as inline markdown (same shape as the existing setext heading parser).
- **Link/image titles** share a new `urlToken` (whitespace- and `)`-terminated) and `titleClause` (leading-space-separated `"..."`/`'...'`) — the URL no longer slurps via `iManyTillStr(")")` so the title is unambiguous.
- **Code spans** use `count(char(\"`\"))` for the opening run, a body of `noneOf(\"`\")` atoms or tick-runs whose length is *not* N (`not(tickRunOf(n))` lookahead), then a closer of exactly N ticks not followed by another ```. The opener count threads into the closer via a small wrapper; everything else stays combinator-shaped.
- **Soft breaks** export a `softBreakParser` (single `\n` with `not(\n)` lookahead) that is *only* used inside `paragraphInline` — adding it to `inlineMarkdownParser`'s top-level `or` would have changed every other block's behaviour. Hard breaks (`"  \n"` / `"\\\n"`) still win because they're matched earlier in the same `or`.

## Validation
- `npx vitest run` → 396/396 passing (+20 new tests).
- `npm run test:tsc` clean modulo the two pre-existing errors on `main` (`regex` export, `vitest.globals` module).