### PR TITLE
Markdown example: inline HTML passthrough

### DIFF
--- a/tests/examples/markdown/index.test.ts
+++ b/tests/examples/markdown/index.test.ts
@@ -78,6 +78,25 @@ describe("markdownParser integration", () => {
     }
   });
 
+  it("rounds-trips inline HTML inside a paragraph", () => {
+    const res = markdownParser(`Hello <span class="hi">world</span>!`);
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.result).toEqual([
+        {
+          type: "paragraph",
+          content: [
+            { type: "inline-text", content: "Hello " },
+            { type: "inline-html", content: `<span class="hi">` },
+            { type: "inline-text", content: "world" },
+            { type: "inline-html", content: "</span>" },
+            { type: "inline-text", content: "!" },
+          ],
+        },
+      ]);
+    }
+  });
+
   it("nested inlines round-trip through markdownParser", () => {
     const res = markdownParser(
       "Try **[the docs](https://x.dev)** or *`run --help`* now."

--- a/tests/examples/markdown/inline.test.ts
+++ b/tests/examples/markdown/inline.test.ts
@@ -666,3 +666,41 @@ describe("htmlCommentParser", () => {
     expect(htmlCommentParser("<!-- a>-->").success).toBe(false);
   });
 });
+
+describe("inline HTML dispatched via inlineMarkdownParser", () => {
+  it("parses an inline tag mid-paragraph", () => {
+    const res = inlineMarkdownParser(`<span class="x">`);
+    expect(res.success).toBe(true);
+    if (res.success) expect(res.result.type).toBe("inline-html");
+  });
+
+  it("parses a self-closing <br/> mid-paragraph", () => {
+    const res = inlineMarkdownParser("<br/>");
+    expect(res.success).toBe(true);
+    if (res.success) expect(res.result.type).toBe("inline-html");
+  });
+
+  it("parses a close tag mid-paragraph", () => {
+    const res = inlineMarkdownParser("</span>");
+    expect(res.success).toBe(true);
+    if (res.success) expect(res.result.type).toBe("inline-html");
+  });
+
+  it("parses a comment mid-paragraph", () => {
+    const res = inlineMarkdownParser("<!-- hi -->");
+    expect(res.success).toBe(true);
+    if (res.success) expect(res.result.type).toBe("inline-html");
+  });
+
+  it("does NOT steal <https://x.y> from autolinkParser", () => {
+    const res = inlineMarkdownParser("<https://x.y>");
+    expect(res.success).toBe(true);
+    if (res.success) expect(res.result.type).toBe("inline-link");
+  });
+
+  it("does NOT steal <a@b.com> from emailAutolinkParser", () => {
+    const res = inlineMarkdownParser("<a@b.com>");
+    expect(res.success).toBe(true);
+    if (res.success) expect(res.result.type).toBe("inline-link");
+  });
+});

--- a/tests/examples/markdown/inline.test.ts
+++ b/tests/examples/markdown/inline.test.ts
@@ -14,6 +14,7 @@ import {
   inlineCodeParser,
   htmlOpenTagParser,
   htmlCloseTagParser,
+  htmlCommentParser,
 } from "./inline";
 
 describe("inlineSeqUntil", () => {
@@ -641,5 +642,27 @@ describe("htmlCloseTagParser", () => {
 
   it("fails on a non-tag close", () => {
     expect(htmlCloseTagParser("< /a>").success).toBe(false);
+  });
+});
+
+describe("htmlCommentParser", () => {
+  it.each<[string]>([
+    ["<!---->"],
+    ["<!-- hi -->"],
+    ["<!-- line1\nline2 -->"],
+    ["<!-- foo > bar -->"],
+  ])("parses %j", (input) => {
+    const res = htmlCommentParser(input);
+    expect(res.success).toBe(true);
+    if (res.success) expect(res.result.content).toBe(input);
+  });
+
+  it("rejects content containing --", () => {
+    expect(htmlCommentParser("<!-- a -- b -->").success).toBe(false);
+  });
+
+  it("rejects content starting or ending with >", () => {
+    expect(htmlCommentParser("<!-->-->").success).toBe(false);
+    expect(htmlCommentParser("<!-- a>-->").success).toBe(false);
   });
 });

--- a/tests/examples/markdown/inline.test.ts
+++ b/tests/examples/markdown/inline.test.ts
@@ -13,6 +13,7 @@ import {
   imageParser,
   inlineCodeParser,
   htmlOpenTagParser,
+  htmlCloseTagParser,
 } from "./inline";
 
 describe("inlineSeqUntil", () => {
@@ -623,5 +624,22 @@ describe("htmlOpenTagParser", () => {
   it("fails on a non-tag", () => {
     expect(htmlOpenTagParser("<https://x>").success).toBe(false);
     expect(htmlOpenTagParser("<a@b.com>").success).toBe(false);
+  });
+});
+
+describe("htmlCloseTagParser", () => {
+  it.each<[string]>([
+    ["</a>"],
+    ["</span>"],
+    ["</a >"],
+    ["</a   >"],
+  ])("parses %j as inline-html", (input) => {
+    const res = htmlCloseTagParser(input);
+    expect(res.success).toBe(true);
+    if (res.success) expect(res.result.content).toBe(input);
+  });
+
+  it("fails on a non-tag close", () => {
+    expect(htmlCloseTagParser("< /a>").success).toBe(false);
   });
 });

--- a/tests/examples/markdown/inline.test.ts
+++ b/tests/examples/markdown/inline.test.ts
@@ -12,6 +12,7 @@ import {
   inlineLinkParser,
   imageParser,
   inlineCodeParser,
+  htmlOpenTagParser,
 } from "./inline";
 
 describe("inlineSeqUntil", () => {
@@ -596,5 +597,31 @@ describe("literal-delimiter fallback", () => {
     const res = inlineMarkdownParser("_word");
     expect(res.success).toBe(true);
     if (res.success) expect(res.result).toEqual({ type: "inline-text", content: "_" });
+  });
+});
+
+describe("htmlOpenTagParser", () => {
+  it.each<[string]>([
+    ["<a>"],
+    ["<span>"],
+    ["<a href>"],
+    [`<a href="x">`],
+    [`<a href='x'>`],
+    [`<a href="x" class="y">`],
+    [`<a  href = "x"  >`],
+    ["<br/>"],
+    ["<br />"],
+  ])("parses %j as inline-html", (input) => {
+    const res = htmlOpenTagParser(input);
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.result.type).toBe("inline-html");
+      expect(res.result.content).toBe(input);
+    }
+  });
+
+  it("fails on a non-tag", () => {
+    expect(htmlOpenTagParser("<https://x>").success).toBe(false);
+    expect(htmlOpenTagParser("<a@b.com>").success).toBe(false);
   });
 });

--- a/tests/examples/markdown/inline.ts
+++ b/tests/examples/markdown/inline.ts
@@ -17,7 +17,7 @@ import {
   exactly,
   lazy,
 } from "@/lib/combinators";
-import { str, char, eof, set, oneOf, alphanum, noneOf, digit } from "@/lib/parsers";
+import { str, char, eof, set, oneOf, alphanum, noneOf, digit, letter } from "@/lib/parsers";
 import { Parser, success, failure } from "@/lib/types";
 import {
   InlineMarkdown,
@@ -34,6 +34,7 @@ import {
   InlineRefLink,
   InlineRefImage,
   InlineFootnoteRef,
+  InlineHTML,
 } from "./types";
 
 import { optional, between } from "@/lib/combinators";
@@ -339,6 +340,98 @@ export const bareUrlAutolinkParser: Parser<InlineLink> = map(
       url,
     };
   }
+);
+
+/* Inline HTML passthrough.
+ *
+ * Three CommonMark shapes are supported (each in its own exported parser):
+ *   - open / self-closing tags: `<a>`, `<a href="x">`, `<br/>`,
+ *   - close tags: `</a>`, `</a   >`,
+ *   - comments: `<!-- … -->`.
+ *
+ * The output is always an `InlineHTML` node whose `content` is the raw source
+ * (including the angle brackets), so downstream renderers pass it through
+ * untouched. We do not try to balance opens/closes or sanitise anything.
+ *
+ * The pieces below are shared helpers: `htmlTagName`, `htmlAttribute`,
+ * `htmlAttributes`, `htmlWS`. All built from combinators with named
+ * captures so the reconstructed string mirrors the source exactly. */
+const htmlWS: Parser<string> = manyWithJoin(oneOf(" \t\n"));
+const htmlWS1: Parser<string> = many1WithJoin(oneOf(" \t\n"));
+
+const htmlTagName: Parser<string> = map(
+  seqC(
+    capture(letter, "first"),
+    capture(manyWithJoin(or(alphanum, char("-"))), "rest")
+  ),
+  ({ first, rest }) => first + rest
+);
+
+const htmlAttrName: Parser<string> = map(
+  seqC(
+    capture(or(letter, char("_"), char(":")), "first"),
+    capture(manyWithJoin(or(alphanum, oneOf("_:.-"))), "rest")
+  ),
+  ({ first, rest }) => first + rest
+);
+
+const dqAttrValue: Parser<string> = map(
+  seqC(char('"'), capture(manyTillStr('"'), "v"), char('"')),
+  ({ v }) => `"${v}"`
+);
+
+const sqAttrValue: Parser<string> = map(
+  seqC(char("'"), capture(manyTillStr("'"), "v"), char("'")),
+  ({ v }) => `'${v}'`
+);
+
+const unquotedAttrValue: Parser<string> = many1WithJoin(noneOf(" \t\n\"'=<>`"));
+
+const htmlAttrValue: Parser<string> = or(dqAttrValue, sqAttrValue, unquotedAttrValue);
+
+/* Optional `= value` suffix on an attribute. Whitespace is allowed on both
+ * sides of the `=` per CommonMark. */
+const htmlAttrEq: Parser<string> = map(
+  seqC(
+    capture(htmlWS, "wsBefore"),
+    char("="),
+    capture(htmlWS, "wsAfter"),
+    capture(htmlAttrValue, "v")
+  ),
+  ({ wsBefore, wsAfter, v }) => `${wsBefore}=${wsAfter}${v}`
+);
+
+const htmlAttribute: Parser<string> = map(
+  seqC(
+    capture(htmlAttrName, "name"),
+    capture(optional(htmlAttrEq), "eq")
+  ),
+  ({ name, eq }) => name + (eq ?? "")
+);
+
+/* Zero or more attributes, each separated from the previous token by
+ * at least one whitespace char. Returns the joined source (including the
+ * separating whitespace) so the outer parser can reconstruct the original. */
+const htmlAttributes: Parser<string> = manyWithJoin(
+  map(
+    seqC(capture(htmlWS1, "ws"), capture(htmlAttribute, "attr")),
+    ({ ws, attr }) => ws + attr
+  )
+);
+
+export const htmlOpenTagParser: Parser<InlineHTML> = map(
+  seqC(
+    char("<"),
+    capture(htmlTagName, "name"),
+    capture(htmlAttributes, "attrs"),
+    capture(htmlWS, "ws"),
+    capture(optional(char("/")), "selfClose"),
+    char(">")
+  ),
+  ({ name, attrs, ws, selfClose }) => ({
+    type: "inline-html" as const,
+    content: `<${name}${attrs}${ws}${selfClose ?? ""}>`,
+  })
 );
 
 // Footnote reference: `[^id]` (id has no `]`, `\n`, or spaces).

--- a/tests/examples/markdown/inline.ts
+++ b/tests/examples/markdown/inline.ts
@@ -434,6 +434,19 @@ export const htmlOpenTagParser: Parser<InlineHTML> = map(
   })
 );
 
+export const htmlCloseTagParser: Parser<InlineHTML> = map(
+  seqC(
+    str("</"),
+    capture(htmlTagName, "name"),
+    capture(htmlWS, "ws"),
+    char(">")
+  ),
+  ({ name, ws }) => ({
+    type: "inline-html" as const,
+    content: `</${name}${ws}>`,
+  })
+);
+
 // Footnote reference: `[^id]` (id has no `]`, `\n`, or spaces).
 export const inlineFootnoteRefParser: Parser<InlineFootnoteRef> = seqC(
   set("type", "inline-footnote-ref"),

--- a/tests/examples/markdown/inline.ts
+++ b/tests/examples/markdown/inline.ts
@@ -497,6 +497,17 @@ export const htmlCommentParser: Parser<InlineHTML> = map(
   })
 );
 
+/* Inline HTML dispatch. `htmlCommentParser` runs first so `<!--…-->` isn't
+ * stolen by `htmlOpenTagParser` (which would otherwise see `<!` and bail).
+ * `htmlCloseTagParser` runs before `htmlOpenTagParser` because the open-tag
+ * parser would accept `<` followed by a tag name and we want `</a>` to win
+ * over an attempted `<` + `/a` (which isn't a valid attribute shape anyway). */
+export const htmlInlineParser: Parser<InlineHTML> = or(
+  htmlCommentParser,
+  htmlCloseTagParser,
+  htmlOpenTagParser
+);
+
 // Footnote reference: `[^id]` (id has no `]`, `\n`, or spaces).
 export const inlineFootnoteRefParser: Parser<InlineFootnoteRef> = seqC(
   set("type", "inline-footnote-ref"),
@@ -639,6 +650,7 @@ export const inlineMarkdownParser: Parser<InlineMarkdown> = or(
   inlineStrikeParser,
   autolinkParser,
   bareUrlAutolinkParser,
+  htmlInlineParser,
   imageParser,
   inlineRefImageParser,
   inlineFootnoteRefParser,

--- a/tests/examples/markdown/inline.ts
+++ b/tests/examples/markdown/inline.ts
@@ -17,7 +17,7 @@ import {
   exactly,
   lazy,
 } from "@/lib/combinators";
-import { str, char, eof, set, oneOf, alphanum, noneOf, digit, letter } from "@/lib/parsers";
+import { str, char, eof, set, oneOf, alphanum, noneOf, digit, letter, anyChar } from "@/lib/parsers";
 import { Parser, success, failure } from "@/lib/types";
 import {
   InlineMarkdown,
@@ -444,6 +444,56 @@ export const htmlCloseTagParser: Parser<InlineHTML> = map(
   ({ name, ws }) => ({
     type: "inline-html" as const,
     content: `</${name}${ws}>`,
+  })
+);
+
+/* HTML comments: `<!-- … -->`. CommonMark rules:
+ *   - the body may not contain `--`,
+ *   - the body may not start or end with `>`.
+ *
+ * Expressed as pure combinators by baking the constraints into the body atom:
+ *   - `not(str("-->"))` so we stop cleanly at the closer,
+ *   - `not(str("--"))` rejects a `--` mid-body,
+ *   - `not(seqR(char(">"), str("-->")))` is the "end-of-body `>` " rule —
+ *     a `>` directly before the closer is rejected, since accepting it
+ *     would let the comment end on `>`.
+ *
+ * The start-of-body `>` rule is enforced with one `not(char(">"))` placed
+ * before the body's `many1`. An empty body falls through to `optional`'s
+ * null branch, which leaves the input unconsumed so the closer can match
+ * immediately. */
+const commentBodyChar: Parser<string> = map(
+  seqC(
+    not(str("-->")),
+    not(str("--")),
+    not(seqR(char(">"), str("-->"))),
+    capture(anyChar, "c")
+  ),
+  ({ c }) => c
+);
+
+const commentBody: Parser<string> = map(
+  optional(
+    map(
+      seqC(
+        not(char(">")),
+        capture(many1WithJoin(commentBodyChar), "body")
+      ),
+      ({ body }) => body
+    )
+  ),
+  (body) => body ?? ""
+);
+
+export const htmlCommentParser: Parser<InlineHTML> = map(
+  seqC(
+    str("<!--"),
+    capture(commentBody, "body"),
+    str("-->")
+  ),
+  ({ body }) => ({
+    type: "inline-html" as const,
+    content: `<!--${body}-->`,
   })
 );
 

--- a/tests/examples/markdown/types.ts
+++ b/tests/examples/markdown/types.ts
@@ -13,7 +13,14 @@ export type InlineMarkdown =
   | Image
   | InlineRefLink
   | InlineRefImage
-  | InlineFootnoteRef;
+  | InlineFootnoteRef
+  | InlineHTML;
+
+export type InlineHTML = {
+  type: "inline-html";
+  /** Raw passthrough source including angle brackets. */
+  content: string;
+};
 
 export type InlineText = {
   type: "inline-text";


### PR DESCRIPTION
Adds inline HTML passthrough to the markdown example — open tags, close tags, self-closing tags, and HTML comments — so common snippets like `Hello <span class="hi">world</span>!` and `<br/>` mid-paragraph round-trip through the AST instead of being mangled by the literal-`<` fallback.

## Commits

| SHA | Type | Summary |
| --- | --- | --- |
| 5db2c80 | feat | `InlineHTML` AST type added to the `InlineMarkdown` union |
| 4200449 | feat | `htmlOpenTagParser` (open + self-closing) plus shared tag-name / attribute helpers |
| 0aefdb2 | feat | `htmlCloseTagParser` for `</tag>` |
| f4e1811 | feat | `htmlCommentParser` for `<!-- … -->` |
| eca4e75 | feat | Dispatch via `htmlInlineParser` in `inlineMarkdownParser` (after autolinks, before text) |
| 1f45a77 | test | End-to-end smoke test through `markdownParser` |

## Design notes

- **One opaque AST node.** Every shape collapses to a single `InlineHTML = { type: "inline-html", content: string }` carrying the raw source (including angle brackets). No tree balancing, no sanitisation. Downstream renderers pass it through.
- **Shared building blocks** in [tests/examples/markdown/inline.ts](https://github.com/egonSchiele/tarsec/blob/feature/markdown-inline-html/tests/examples/markdown/inline.ts): `htmlTagName` (letter + `[a-zA-Z0-9-]*`), `htmlAttrName`, `htmlAttrValue` (`"…"`/`'…'`/unquoted), `htmlAttribute`, `htmlAttributes`, `htmlWS`/`htmlWS1`. All combinator-built via `seqC` + named `capture` so the reconstructed string mirrors the source exactly.
- **No hand-rolled `(input) => {...}` wrappers in this PR.** The comment parser is the case the plan flagged as "hand-rolled"; I worked through it as pure combinators instead. CommonMark's three constraints (no `-->` inside body, no `--` inside body, body can't start/end with `>`) are all baked into the body atom set:
  - `not(str("-->"))` stops at the closer
  - `not(str("--"))` rejects mid-body `--`
  - `not(seqR(char(">"), str("-->")))` is the end-of-body `>` rule (a `>` directly before the closer is rejected)
  - and a single `not(char(">"))` placed before the body's `many1` handles start-of-body `>`. An empty body falls through to `optional`'s null branch, which leaves input unconsumed so the closer matches immediately. See [the `commentBody` block](https://github.com/egonSchiele/tarsec/blob/feature/markdown-inline-html/tests/examples/markdown/inline.ts) with a commented derivation.
- **Dispatch order in `htmlInlineParser`'s `or`:** comment → close → open. Comment first so `<!--…-->` isn't intercepted by an open-tag attempt at `<!`. Close before open so `</a>` wins cleanly.
- **Dispatch order in `inlineMarkdownParser`'s `or`:** `htmlInlineParser` is inserted **after** `autolinkParser`/`bareUrlAutolinkParser` so `<https://x>` still produces an `inline-link` and `<a@b.com>` still produces a `mailto:` link; the inline HTML parsers only fire when the input is actually tag- or comment-shaped.
- **`paragraphParser` and `htmlBlockParser` unchanged.** The block form still wins at line start (no overlap because the block parser runs before any inline dispatch); the inline form only competes inside an already-running inline context.
- **No CHANGELOG/README update.** Following the PR #8 feedback that we don't need to update those for example-only additions.

## Edge cases covered by tests

- `<a>`, `<span>`, `<a href>`, `<a href="x">`, `<a href='x'>`, `<a href="x" class="y">`, `<a  href = "x"  >`, `<br/>`, `<br />`
- `</a>`, `</span>`, `</a >`, `</a   >`
- `<!---->` (empty body), `<!-- hi -->`, `<!-- line1\nline2 -->`, `<!-- foo > bar -->` (middle `>` allowed)
- Rejected: `<!-- a -- b -->` (mid-body `--`), `<!-->-->` (leading `>`), `<!-- a>-->` (trailing `>`)
- `< /a>` (space-before-tag-name) — fails as a close tag
- `<https://x>` → `inline-link` (autolink wins)
- `<a@b.com>` → `inline-link` with `mailto:` (autolink wins)
- Smoke test: `Hello <span class="hi">world</span>!` round-trips to `[text, html, text, html, text]`

## Validation

- `npx vitest run` — **463 / 463 passing** (was 445 on `main`; +18 new tests across the four phases plus the smoke test)
- `npm run test:tsc` — clean modulo the two pre-existing errors on `main` (`regex` export, `vitest.globals` module)

## Files touched

- `tests/examples/markdown/types.ts` — `InlineHTML` added to the union
- `tests/examples/markdown/inline.ts` — helpers + three parsers + `htmlInlineParser` union + dispatch
- `tests/examples/markdown/inline.test.ts` — four `describe` blocks (open/close/comment/dispatch)
- `tests/examples/markdown/index.test.ts` — one end-to-end paragraph round-trip
