### PR TITLE
markdown parser: don't stop inline-text on stray double-spaces

### DIFF
--- a/lib/parsers/markdown/index.ts
+++ b/lib/parsers/markdown/index.ts
@@ -5,6 +5,9 @@ export * from "./references.js";
 export * from "./frontmatter.js";
 
 import { seq, or, optional, many, capture, seqC, map } from "../../combinators.js";
+import { ParserFailure } from "../../types.js";
+import { TarsecError } from "../../tarsecError.js";
+import { getDiagnostics } from "../../trace.js";
 import { spaces, newline } from "../../parsers.js";
 import {
   headingParser,
@@ -69,8 +72,28 @@ const _markdownParser = seq(
   }
 );
 
-// Resolve [id]: url definitions across the AST after parsing.
-export const markdownParser: Parser<unknown[]> = map(
-  _markdownParser,
-  (nodes) => resolveReferences(nodes as unknown[])
-);
+// Resolve [id]: url definitions across the AST after parsing. Throws
+// TarsecError on parse failure or if the input isn't fully consumed, so
+// silently-truncated parses (the kind that hide list-continuation or
+// indented-fence bugs) surface immediately instead of returning a partial AST.
+export const markdownParser: Parser<unknown[]> = (input) => {
+  const result = _markdownParser(input);
+  if (!result.success) {
+    throw new TarsecError(getDiagnostics(result, input));
+  }
+  if (result.rest.length > 0) {
+    const failure: ParserFailure = {
+      success: false,
+      message: "markdownParser did not consume the full input",
+      rest: result.rest,
+    };
+    throw new TarsecError(
+      getDiagnostics(failure, result.rest, failure.message)
+    );
+  }
+  return {
+    success: true,
+    result: resolveReferences(result.result as unknown[]),
+    rest: result.rest,
+  };
+};

--- a/lib/parsers/markdown/index.ts
+++ b/lib/parsers/markdown/index.ts
@@ -5,9 +5,6 @@ export * from "./references.js";
 export * from "./frontmatter.js";
 
 import { seq, or, optional, many, capture, seqC, map } from "../../combinators.js";
-import { ParserFailure } from "../../types.js";
-import { TarsecError } from "../../tarsecError.js";
-import { getDiagnostics } from "../../trace.js";
 import { spaces, newline } from "../../parsers.js";
 import {
   headingParser,
@@ -72,28 +69,8 @@ const _markdownParser = seq(
   }
 );
 
-// Resolve [id]: url definitions across the AST after parsing. Throws
-// TarsecError on parse failure or if the input isn't fully consumed, so
-// silently-truncated parses (the kind that hide list-continuation or
-// indented-fence bugs) surface immediately instead of returning a partial AST.
-export const markdownParser: Parser<unknown[]> = (input) => {
-  const result = _markdownParser(input);
-  if (!result.success) {
-    throw new TarsecError(getDiagnostics(result, input));
-  }
-  if (result.rest.length > 0) {
-    const failure: ParserFailure = {
-      success: false,
-      message: "markdownParser did not consume the full input",
-      rest: result.rest,
-    };
-    throw new TarsecError(
-      getDiagnostics(failure, result.rest, failure.message)
-    );
-  }
-  return {
-    success: true,
-    result: resolveReferences(result.result as unknown[]),
-    rest: result.rest,
-  };
-};
+// Resolve [id]: url definitions across the AST after parsing.
+export const markdownParser: Parser<unknown[]> = map(
+  _markdownParser,
+  (nodes) => resolveReferences(nodes as unknown[])
+);

--- a/lib/parsers/markdown/inline.ts
+++ b/lib/parsers/markdown/inline.ts
@@ -39,20 +39,24 @@ import {
 
 import { optional, between } from "../../combinators.js";
 
-// Stop inline-text at any single delimiter char OR at the start of a hard-break
-// sequence (two-or-more spaces immediately followed by `\n`). The hard-break
-// stop is a *full* lookahead — checking only `"  "` would let arbitrary
-// double-spaces (e.g. a 2-space line indent inside a list-item continuation)
-// terminate inline-text and leave the surrounding paragraph stuck. `]` is
-// included so inline-text inside a link-text (`[...]`) ends at the `]`.
-const hardBreakLookahead: Parser<unknown> = seqR(
+// The "two-or-more trailing spaces then `\n`" half of a hard break. Shared
+// between `hardBreakParser` (which emits the hard-break node) and
+// `inlineTextStop` (which uses it to know where to stop). Keeping these in
+// sync matters: if the run pattern here disagreed with what `hardBreakParser`
+// accepts, inline-text could either swallow a real hard break or — as the
+// previous `str("  ")` did — stop on any incidental double-space (e.g. a
+// 2-space line indent inside a list-item continuation) and freeze the
+// surrounding paragraph at zero progress.
+const hardBreakSpaces: Parser<unknown> = seqR(
   str("  "),
   many(char(" ")),
   char("\n")
 );
+
+// `]` is included so inline-text inside a link-text (`[...]`) ends at the `]`.
 const inlineTextStop: Parser<unknown> = or(
   oneOf("*_`[]!<~\\&\n"),
-  hardBreakLookahead
+  hardBreakSpaces
 );
 
 export const inlineTextParser: Parser<InlineText> = map(
@@ -576,7 +580,7 @@ export const imageParser: Parser<Image> = map(
 export const hardBreakParser: Parser<InlineHardBreak> = map(
   or(
     // two-or-more trailing spaces then newline
-    seqR(str("  "), many(char(" ")), char("\n")),
+    hardBreakSpaces,
     // backslash then newline
     seqR(char("\\"), char("\n"))
   ),

--- a/lib/parsers/markdown/inline.ts
+++ b/lib/parsers/markdown/inline.ts
@@ -39,13 +39,20 @@ import {
 
 import { optional, between } from "../../combinators.js";
 
-// Stop inline-text at any single delimiter char OR at a hard-break sequence
-// ("  \n"+). Using many1Till with an `or` of delimiters makes the stop set
-// composable rather than embedded inside a regex. `]` is included so that
-// inline-text inside a link-text (`[...]`) terminates at the closing `]`.
+// Stop inline-text at any single delimiter char OR at the start of a hard-break
+// sequence (two-or-more spaces immediately followed by `\n`). The hard-break
+// stop is a *full* lookahead — checking only `"  "` would let arbitrary
+// double-spaces (e.g. a 2-space line indent inside a list-item continuation)
+// terminate inline-text and leave the surrounding paragraph stuck. `]` is
+// included so inline-text inside a link-text (`[...]`) ends at the `]`.
+const hardBreakLookahead: Parser<unknown> = seqR(
+  str("  "),
+  many(char(" ")),
+  char("\n")
+);
 const inlineTextStop: Parser<unknown> = or(
   oneOf("*_`[]!<~\\&\n"),
-  str("  ")
+  hardBreakLookahead
 );
 
 export const inlineTextParser: Parser<InlineText> = map(

--- a/tests/parsers/markdown/index.test.ts
+++ b/tests/parsers/markdown/index.test.ts
@@ -97,6 +97,27 @@ describe("markdownParser integration", () => {
     }
   });
 
+  it("parses a list item followed by a 2-space-indented fenced code block", () => {
+    // Standard markdown list-item-continuation shape. The indented fence isn't
+    // recognised as a real code block (we don't dedent), but the parser must
+    // still consume the indented lines so `rest` ends up empty.
+    const input = [
+      "- Use the command:",
+      "  ```bash",
+      "  pnpm install agency-lang",
+      "  ```",
+      "",
+      "### After",
+    ].join("\n");
+    const res = markdownParser(input);
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.rest).toBe("");
+      const types = (res.result as any[]).map((b) => b.type);
+      expect(types).toContain("heading");
+    }
+  });
+
   it("parses a heading directly followed by a list (no blank line)", () => {
     const res = markdownParser("## H\n- item");
     expect(res.success).toBe(true);

--- a/tests/parsers/markdown/index.test.ts
+++ b/tests/parsers/markdown/index.test.ts
@@ -114,7 +114,10 @@ describe("markdownParser integration", () => {
     if (res.success) {
       expect(res.rest).toBe("");
       const types = (res.result as any[]).map((b) => b.type);
-      expect(types).toContain("heading");
+      // The indented fence isn't dedented — its body falls through to a
+      // paragraph between the list and the next heading. The important
+      // invariant is that nothing is dropped on the floor.
+      expect(types).toEqual(["list", "paragraph", "heading"]);
     }
   });
 


### PR DESCRIPTION
## Summary
Running `make` on `example.md` silently truncated the document. After parsing `- Use the command:`, the next line was `  ```bash` (two-space-indented fence — standard list-item continuation shape). No block parser accepted it, and `paragraphParser` couldn't either: `inlineTextStop` matched any `"  "` run as a hard-break trigger, so `many1Till` froze at zero chars consumed.

- Replace `str("  ")` in `inlineTextStop` with a real lookahead for the hard-break shape (`"  +\n"`). `hardBreakParser` is unchanged — it still owns the actual hard-break emission.
- Re-add the wrapper that throws `TarsecError` when `markdownParser` leaves any input unconsumed, so silent truncations surface immediately.

## Test plan
- [x] New test: list item followed by a 2-space-indented fenced block parses with `rest === ""`.
- [x] `make` round-trips `example.md` end-to-end (no leftover `rest`).
- [x] Full suite: 446 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
