### PR TITLE
Markdown: nest block-level content inside list items

### DIFF
--- a/lib/parsers/markdown/blocks.ts
+++ b/lib/parsers/markdown/blocks.ts
@@ -24,8 +24,9 @@ import {
   alphanum,
   oneOf,
   noneOf,
+  newline,
 } from "../../parsers.js";
-import { Parser } from "../../types.js";
+import { Parser, success, failure } from "../../types.js";
 import { InlineMarkdown } from "./types.js";
 import {
   Heading,
@@ -40,7 +41,12 @@ import {
   Table,
   Alignment,
   HTMLBlock,
+  Block,
 } from "./types.js";
+import {
+  linkDefinitionParser,
+  footnoteDefinitionParser,
+} from "./references.js";
 import { digit, letter } from "../../parsers.js";
 import { manyTill } from "../../combinators.js";
 import { inlineMarkdownParser, imageParser, softBreakParser } from "./inline.js";
@@ -209,26 +215,33 @@ export const setextHeadingParser: Parser<Heading> = map(
 
 /* Lists.
  *
- * Each item is `marker + " " + line content + \n`. Markers are unordered
- * (`-`, `*`, `+`) or ordered (`<digits>.`). After parsing an item, we
- * recursively try to parse a sublist at `indent + 2`. The marker type of the
- * first item (ordered vs unordered) locks in the whole list; a marker-type
- * switch ends the list.
+ * A list item is a container of blocks. Its body spans the first line and any
+ * subsequent lines indented to the continuation column k = c + m + 1, where c
+ * is the marker column and m is the marker width. The marker family (ordered
+ * vs unordered) is locked by the first item; later items whose family doesn't
+ * match end the list.
  *
- * We build two list parsers — one parameterised by `unorderedMarker`, one
- * by `orderedMarker` — and `or` them. That way the marker-type lock falls
- * out of `seqC` naturally; no manual loop / state needed. */
-type Marker = { ord: boolean; start: number };
+ * The body lines are stripped of their k-space indent (via `indentOf(k)`) as
+ * part of the parse, joined, and reparsed through the top-level block
+ * dispatcher (`blockEntry`). Nested lists, code blocks, paragraphs, etc.
+ * inside an item fall out of that reparse — no special case for sublists. */
+type Marker = { ord: boolean; start: number; width: number };
 
 const unorderedMarker: Parser<Marker> = map(
   oneOf("-*+"),
-  () => ({ ord: false, start: 1 })
+  () => ({ ord: false, start: 1, width: 1 })
 );
 
 const orderedMarker: Parser<Marker> = map(
   seqC(capture(many1WithJoin(digit), "digits"), char(".")),
-  ({ digits }) => ({ ord: true, start: parseInt(digits, 10) })
+  ({ digits }) => ({
+    ord: true,
+    start: parseInt(digits, 10),
+    width: digits.length + 1,
+  })
 );
+
+const anyMarker: Parser<Marker> = or(unorderedMarker, orderedMarker);
 
 const indentOf = (n: number): Parser<unknown> =>
   n > 0 ? str(" ".repeat(n)) : str("");
@@ -244,71 +257,138 @@ const taskCheckbox: Parser<boolean> = map(
   ({ mark }) => mark !== " "
 );
 
-type RawItem = { marker: Marker; line: string; checked?: boolean };
+/* The first line of an item's content — everything after the marker+space
+ * (and optional checkbox), up to `\n`. */
+const itemFirstLine: Parser<string> = map(
+  seqC(capture(manyTillStr("\n"), "line"), or(char("\n"), eof)),
+  ({ line }) => line
+);
 
-const itemHeadOf = (
-  indent: number,
-  markerParser: Parser<Marker>
-): Parser<RawItem> =>
+/* A continuation line: exactly k spaces of indent, then the rest of the line.
+ * The strip IS the parse — `indentOf(k)` consumes the leading indent. */
+const continuationLine = (k: number): Parser<string> =>
   map(
-    seqC(
-      indentOf(indent),
-      capture(markerParser, "marker"),
-      char(" "),
-      capture(optional(taskCheckbox), "checked"),
-      capture(manyTillStr("\n"), "line"),
-      or(char("\n"), eof)
-    ),
-    ({ marker, checked, line }) => {
-      const raw: RawItem = { marker, line };
-      if (checked !== null) raw.checked = checked;
-      return raw;
-    }
+    seqC(indentOf(k), capture(manyTillStr("\n"), "line"), or(char("\n"), eof)),
+    ({ line }) => line
   );
 
-const parseInline = (line: string): InlineMarkdown[] => {
-  const inline = many1(inlineMarkdownParser)(line);
-  return inline.success ? (inline.result as InlineMarkdown[]) : [];
+/* A blank line at line-start. `blocks.ts` already defines `blankLine` below,
+ * but that variant starts with `\n` (designed for inter-block separators).
+ * Here we're already past the previous `\n`, so we need a line-start variant.
+ * The matched value isn't used as data; itemBody normalises blanks to "". */
+const blankContinuation: Parser<unknown> = seqR(
+  many(oneOf(" \t")),
+  or(char("\n"), eof)
+);
+
+/* One line of item body (after the first). Heterogeneous return type:
+ *   - continuationLine -> string (the dedented line text)
+ *   - blankContinuation -> unknown (discardable seqR output)
+ * itemBody normalises blanks to "" inline so a wrapper `map` is unnecessary. */
+const itemContentLine = (k: number): Parser<string | unknown> =>
+  or(continuationLine(k), blankContinuation);
+
+/* Reparse an item's collected body as a sequence of blocks via `blockEntry`.
+ *
+ * No silent fallback. CommonMark guarantees any non-empty buffer produces at
+ * least one block (worst case, a paragraph). The only legitimate empty case
+ * is an item whose first line is empty and which has no continuations — we
+ * handle that explicitly so the invariant `non-empty buf => at least one
+ * block` stays a real invariant. */
+const reparseBlocks = (buf: string): Block[] => {
+  if (buf === "") return [];
+  const r = many1(lazy(() => blockEntry))(buf);
+  if (!r.success) {
+    throw new Error(
+      `reparseBlocks: failed on non-empty buffer: ${JSON.stringify(buf)}`
+    );
+  }
+  return r.result as Block[];
 };
 
-// One list item: an item-head followed by an optional sublist at +2 indent.
-const itemWithSublist = (
-  indent: number,
-  markerParser: Parser<Marker>
-): Parser<{ marker: Marker; item: ListItem }> =>
+/* Full item content: first line + zero-or-more continuation lines, joined
+ * with `\n` and reparsed. */
+const itemBody = (k: number): Parser<Block[]> =>
   map(
     seqC(
-      capture(itemHeadOf(indent, markerParser), "raw"),
-      capture(optional(lazy(() => listParserAt(indent + 2))), "sublist")
+      capture(itemFirstLine, "first"),
+      capture(many(itemContentLine(k)), "rest")
     ),
-    ({ raw, sublist }) => {
-      const item: ListItem = { content: parseInline(raw.line) };
-      if (sublist) item.sublist = sublist;
-      if (raw.checked !== undefined) item.checked = raw.checked;
-      return { marker: raw.marker, item };
+    ({ first, rest }) => {
+      const lines = [
+        first,
+        ...rest.map((r) => (typeof r === "string" ? r : "")),
+      ];
+      return reparseBlocks(lines.join("\n"));
     }
   );
 
-// A list of one or more items that all share a marker family.
-const listOf = (
-  indent: number,
-  markerParser: Parser<Marker>
-): Parser<List> =>
-  map(
-    seqC(
-      capture(itemWithSublist(indent, markerParser), "first"),
-      capture(many(itemWithSublist(indent, markerParser)), "rest")
-    ),
-    ({ first, rest }) => ({
-      type: "list",
-      ordered: first.marker.ord,
-      start: first.marker.start,
-      items: [first.item, ...rest.map((r) => r.item)],
-    })
-  );
+type ParsedItem = { marker: Marker; item: ListItem };
 
-const listParserAt = (indent: number): Parser<List> =>
-  or(listOf(indent, unorderedMarker), listOf(indent, orderedMarker));
+/* Item parser at marker column c. Handwritten because `k` is derived from the
+ * parsed marker's width — `seqC` runs its children in fixed order with no data
+ * flow between them, so we sequence by hand to thread `marker.width` into
+ * `itemBody(k)`. Same shape as `inlineCodeParser` (inline.ts:179), which
+ * threads the opener's tick count into its closer for the same reason. */
+const itemParser = (c: number): Parser<ParsedItem> => (input: string) => {
+  const head = seqC(
+    indentOf(c),
+    capture(anyMarker, "marker"),
+    char(" "),
+    capture(optional(taskCheckbox), "checked")
+  )(input);
+  if (!head.success) return head;
+
+  const { marker, checked } = head.result as {
+    marker: Marker;
+    checked: boolean | null;
+  };
+  const k = c + marker.width + 1;
+
+  const body = itemBody(k)(head.rest);
+  if (!body.success) return body;
+
+  const item: ListItem = { content: body.result };
+  if (checked !== null) item.checked = checked;
+  return success({ marker, item }, body.rest);
+};
+
+/* An item whose marker family matches the locked one. Fails (without
+ * consuming) if the family changed. */
+const itemMatching = (c: number, ord: boolean): Parser<ParsedItem> =>
+  (input: string) => {
+    const r = itemParser(c)(input);
+    if (!r.success) return r;
+    if (r.result.marker.ord !== ord) {
+      return failure("list marker family changed", input);
+    }
+    return r;
+  };
+
+/* A list at column c. Marker family locked by the first item; subsequent
+ * items use `itemMatching` to enforce the lock. */
+const listOf = (c: number): Parser<List> => (input: string) => {
+  const first = itemParser(c)(input);
+  if (!first.success) return first;
+  const ord = first.result.marker.ord;
+  const rest = many(itemMatching(c, ord))(first.rest);
+  if (!rest.success) return rest;
+  const items = [
+    first.result.item,
+    ...(rest.result as ParsedItem[]).map((r) => r.item),
+  ];
+  return success(
+    {
+      type: "list" as const,
+      ordered: ord,
+      start: first.result.marker.start,
+      items,
+    },
+    rest.rest
+  );
+};
+
+const listParserAt = (indent: number): Parser<List> => listOf(indent);
 
 export const listParser: Parser<List> = listParserAt(0);
 
@@ -463,4 +543,31 @@ const paragraphInline: Parser<InlineMarkdown> = map(
 export const paragraphParser: Parser<Paragraph> = map(
   many1(paragraphInline),
   (content) => ({ type: "paragraph", content: content as InlineMarkdown[] })
+);
+
+/* Top-level block dispatcher. Lives here (rather than in index.ts) so
+ * `listParser`'s `reparseBlocks` can recurse through it via `lazy`. */
+export const blockAlt: Parser<Block> = or(
+  setextHeadingParser,
+  horizontalRuleParser,
+  headingParser,
+  codeBlockParser,
+  indentedCodeBlockParser,
+  tableParser,
+  blockQuoteParser,
+  listParser,
+  htmlBlockParser,
+  linkDefinitionParser,
+  footnoteDefinitionParser,
+  paragraphParser,
+  imageParser
+);
+
+/* A block followed by zero-or-more trailing newlines. Blocks differ in
+ * whether they consume their own terminating "\n" (e.g. headingParser does,
+ * codeBlock doesn't), so `sepBy(many1(newline), block)` won't work — it
+ * would fail to separate two blocks when the first already ate its newline. */
+export const blockEntry: Parser<Block> = map(
+  seqC(capture(blockAlt, "b"), many(newline)),
+  ({ b }) => b as Block
 );

--- a/lib/parsers/markdown/blocks.ts
+++ b/lib/parsers/markdown/blocks.ts
@@ -275,10 +275,15 @@ const continuationLine = (k: number): Parser<string> =>
 /* A blank line at line-start. `blocks.ts` already defines `blankLine` below,
  * but that variant starts with `\n` (designed for inter-block separators).
  * Here we're already past the previous `\n`, so we need a line-start variant.
- * The matched value isn't used as data; itemBody normalises blanks to "". */
+ *
+ * We do NOT allow `eof` here: at end-of-input with no trailing whitespace
+ * this would succeed without consuming anything, and `many(itemContentLine(k))`
+ * would either spin or append a phantom blank. The final line of an item body
+ * is handled by `continuationLine`'s own `or(char("\n"), eof)`. The matched
+ * value isn't used as data; itemBody normalises blanks to "". */
 const blankContinuation: Parser<unknown> = seqR(
   many(oneOf(" \t")),
-  or(char("\n"), eof)
+  char("\n")
 );
 
 /* One line of item body (after the first). Heterogeneous return type:
@@ -290,17 +295,19 @@ const itemContentLine = (k: number): Parser<string | unknown> =>
 
 /* Reparse an item's collected body as a sequence of blocks via `blockEntry`.
  *
- * No silent fallback. CommonMark guarantees any non-empty buffer produces at
- * least one block (worst case, a paragraph). The only legitimate empty case
- * is an item whose first line is empty and which has no continuations — we
- * handle that explicitly so the invariant `non-empty buf => at least one
- * block` stays a real invariant. */
+ * List item bodies can legitimately begin with blank lines — e.g.
+ * `- \n\n  - inner` collects `"\n- inner"`, and `- ` alone collects `"\n"`.
+ * Strip leading newlines (they carry no AST content) before handing to
+ * `many1(blockEntry)`. After trimming, the invariant `non-empty buf =>
+ * at least one block` holds (CommonMark falls back to a paragraph), so a
+ * parse failure here is a genuine parser bug worth surfacing. */
 const reparseBlocks = (buf: string): Block[] => {
-  if (buf === "") return [];
-  const r = many1(lazy(() => blockEntry))(buf);
+  const trimmed = buf.replace(/^\n+/, "");
+  if (trimmed === "") return [];
+  const r = many1(lazy(() => blockEntry))(trimmed);
   if (!r.success) {
     throw new Error(
-      `reparseBlocks: failed on non-empty buffer: ${JSON.stringify(buf)}`
+      `reparseBlocks: failed on non-empty buffer: ${JSON.stringify(trimmed)}`
     );
   }
   return r.result as Block[];

--- a/lib/parsers/markdown/index.ts
+++ b/lib/parsers/markdown/index.ts
@@ -4,56 +4,14 @@ export * from "./blocks.js";
 export * from "./references.js";
 export * from "./frontmatter.js";
 
-import { seq, or, optional, many, capture, seqC, map } from "../../combinators.js";
-import { spaces, newline } from "../../parsers.js";
-import {
-  headingParser,
-  codeBlockParser,
-  blockQuoteParser,
-  paragraphParser,
-  imageParser,
-  horizontalRuleParser,
-  setextHeadingParser,
-  indentedCodeBlockParser,
-  listParser,
-  tableParser,
-  htmlBlockParser,
-} from "./blocks.js";
-import {
-  linkDefinitionParser,
-  footnoteDefinitionParser,
-  resolveReferences,
-} from "./references.js";
+import { seq, optional, many, map } from "../../combinators.js";
+import { spaces } from "../../parsers.js";
+import { blockEntry } from "./blocks.js";
+import { resolveReferences } from "./references.js";
 import { frontmatterParser } from "./frontmatter.js";
 import { Frontmatter } from "./types.js";
 
 import { Parser } from "../../types.js";
-
-const blockAlt = or(
-  setextHeadingParser,
-  horizontalRuleParser,
-  headingParser,
-  codeBlockParser,
-  indentedCodeBlockParser,
-  tableParser,
-  blockQuoteParser,
-  listParser,
-  htmlBlockParser,
-  linkDefinitionParser,
-  footnoteDefinitionParser,
-  paragraphParser,
-  imageParser
-);
-
-// A block followed by zero-or-more trailing newlines. Blocks differ in whether
-// they consume their own terminating "\n" (e.g. headingParser does, codeBlock
-// doesn't), so we can't use sepBy(many1(newline), block) — it would fail to
-// separate two blocks when the first already ate its newline (e.g. a heading
-// directly followed by a list with no intervening blank line).
-const blockEntry = map(
-  seqC(capture(blockAlt, "b"), many(newline)),
-  ({ b }) => b
-);
 
 const _markdownParser = seq(
   [

--- a/lib/parsers/markdown/index.ts
+++ b/lib/parsers/markdown/index.ts
@@ -9,11 +9,11 @@ import { spaces } from "../../parsers.js";
 import { blockEntry } from "./blocks.js";
 import { resolveReferences } from "./references.js";
 import { frontmatterParser } from "./frontmatter.js";
-import { Frontmatter } from "./types.js";
+import { Block, Frontmatter, MarkdownNode } from "./types.js";
 
 import { Parser } from "../../types.js";
 
-const _markdownParser = seq(
+const _markdownParser: Parser<MarkdownNode[]> = seq(
   [
     optional(frontmatterParser),
     optional(spaces),
@@ -22,13 +22,13 @@ const _markdownParser = seq(
   ],
   (r) => {
     const fm = r[0] as Frontmatter | null;
-    const blocks = r[2] as unknown[];
+    const blocks = r[2] as Block[];
     return fm ? [fm, ...blocks] : blocks;
   }
 );
 
 // Resolve [id]: url definitions across the AST after parsing.
-export const markdownParser: Parser<unknown[]> = map(
+export const markdownParser: Parser<MarkdownNode[]> = map(
   _markdownParser,
-  (nodes) => resolveReferences(nodes as unknown[])
+  (nodes) => resolveReferences(nodes as unknown[]) as MarkdownNode[]
 );

--- a/lib/parsers/markdown/references.ts
+++ b/lib/parsers/markdown/references.ts
@@ -108,12 +108,13 @@ export function resolveReferences(ast: unknown[]): unknown[] {
       return { type: "inline-text", content: `[^${obj.id}]` };
     }
 
-    // recurse into known child-bearing fields
+    // recurse into known child-bearing fields. Nested lists now live inside
+    // a list item's `content` (alongside other block children), so no
+    // dedicated `sublist` traversal is needed.
     const out: Record<string, unknown> = { ...obj };
     for (const key of ["content", "items", "rows"]) {
       if (Array.isArray(obj[key])) out[key] = (obj[key] as unknown[]).map(walk);
     }
-    if (obj.sublist) out.sublist = walk(obj.sublist);
     return out;
   }
 

--- a/lib/parsers/markdown/references.ts
+++ b/lib/parsers/markdown/references.ts
@@ -50,25 +50,46 @@ export const footnoteDefinitionParser: Parser<FootnoteDef> = seqC(
 
 /* Resolution pass.
  *
- * Walk the AST. Collect link-definitions, then rewrite ref nodes to inline
- * links/images and strip the definitions. Id matching is case-insensitive. */
+ * Walk the AST. Collect link/footnote definitions (deeply — they can now
+ * appear nested inside list-item block children), then rewrite ref nodes to
+ * inline links/images and strip the definitions everywhere they appear. Id
+ * matching is case-insensitive. */
+const CHILD_KEYS = ["content", "items", "rows"] as const;
+
+const isDef = (n: unknown): boolean =>
+  isObj(n) &&
+  ((n as any).type === "link-definition" ||
+    (n as any).type === "footnote-definition");
+
 export function resolveReferences(ast: unknown[]): unknown[] {
   const linkDefs = new Map<string, LinkDef>();
   const footnoteDefs = new Map<string, FootnoteDef>();
-  for (const node of ast) {
-    if (!isObj(node)) continue;
-    const t = (node as any).type;
+
+  function collect(node: unknown): void {
+    if (Array.isArray(node)) {
+      node.forEach(collect);
+      return;
+    }
+    if (!isObj(node)) return;
+    const obj = node as Record<string, unknown>;
+    const t = obj.type;
     if (t === "link-definition") {
-      const def = node as LinkDef;
+      const def = obj as unknown as LinkDef;
       linkDefs.set(def.id.toLowerCase(), def);
     } else if (t === "footnote-definition") {
-      const def = node as FootnoteDef;
+      const def = obj as unknown as FootnoteDef;
       footnoteDefs.set(def.id.toLowerCase(), def);
     }
+    for (const key of CHILD_KEYS) {
+      if (Array.isArray(obj[key])) (obj[key] as unknown[]).forEach(collect);
+    }
   }
+  collect(ast);
 
   function walk(node: unknown): unknown {
-    if (Array.isArray(node)) return node.map(walk);
+    if (Array.isArray(node)) {
+      return node.filter((n) => !isDef(n)).map(walk);
+    }
     if (!isObj(node)) return node;
     const obj = node as Record<string, unknown>;
 
@@ -108,26 +129,17 @@ export function resolveReferences(ast: unknown[]): unknown[] {
       return { type: "inline-text", content: `[^${obj.id}]` };
     }
 
-    // recurse into known child-bearing fields. Nested lists now live inside
-    // a list item's `content` (alongside other block children), so no
-    // dedicated `sublist` traversal is needed.
+    // Recurse into known child-bearing fields. The array path through `walk`
+    // also strips nested link/footnote definitions, so list items, blockquotes,
+    // etc. all get the same treatment as the top-level array.
     const out: Record<string, unknown> = { ...obj };
-    for (const key of ["content", "items", "rows"]) {
-      if (Array.isArray(obj[key])) out[key] = (obj[key] as unknown[]).map(walk);
+    for (const key of CHILD_KEYS) {
+      if (Array.isArray(obj[key])) out[key] = walk(obj[key]);
     }
     return out;
   }
 
-  return ast
-    .filter(
-      (n) =>
-        !(
-          isObj(n) &&
-          ((n as any).type === "link-definition" ||
-            (n as any).type === "footnote-definition")
-        )
-    )
-    .map(walk);
+  return walk(ast) as unknown[];
 }
 
 function isObj(v: unknown): v is object {

--- a/lib/parsers/markdown/types.ts
+++ b/lib/parsers/markdown/types.ts
@@ -128,6 +128,9 @@ export type Block =
   | LinkDef
   | FootnoteDef;
 
+/** Top-level node in the markdown AST (optionally prefixed by frontmatter). */
+export type MarkdownNode = Block | Frontmatter;
+
 export type List = {
   type: "list";
   ordered: boolean;

--- a/lib/parsers/markdown/types.ts
+++ b/lib/parsers/markdown/types.ts
@@ -110,11 +110,23 @@ export type InlineRefImage = {
 };
 
 export type ListItem = {
-  content: InlineMarkdown[];
-  sublist?: List;
+  content: Block[];
   /** GFM task-list state: `true` for `[x]`/`[X]`, `false` for `[ ]`, absent for plain items. */
   checked?: boolean;
 };
+
+export type Block =
+  | Paragraph
+  | Heading
+  | CodeBlock
+  | List
+  | BlockQuote
+  | HorizontalRule
+  | Table
+  | HTMLBlock
+  | Image
+  | LinkDef
+  | FootnoteDef;
 
 export type List = {
   type: "list";

--- a/tests/parsers/markdown/blocks.test.ts
+++ b/tests/parsers/markdown/blocks.test.ts
@@ -181,9 +181,9 @@ describe("listParser unordered", () => {
       expect(res.result.type).toBe("list");
       expect(res.result.ordered).toBe(false);
       expect(res.result.items.map((i) => i.content)).toEqual([
-        [{ type: "inline-text", content: "a" }],
-        [{ type: "inline-text", content: "b" }],
-        [{ type: "inline-text", content: "c" }],
+        [{ type: "paragraph", content: [{ type: "inline-text", content: "a" }] }],
+        [{ type: "paragraph", content: [{ type: "inline-text", content: "b" }] }],
+        [{ type: "paragraph", content: [{ type: "inline-text", content: "c" }] }],
       ]);
     }
   });
@@ -254,11 +254,159 @@ describe("listParser nested", () => {
     if (res.success) {
       expect(res.result.items.length).toBe(2);
       const first = res.result.items[0];
-      expect(first.sublist).toBeDefined();
-      if (first.sublist) {
-        expect(first.sublist.items.length).toBe(2);
+      // The sublist now lives inside the item's content blocks rather than
+      // on a dedicated `sublist` field.
+      const sublist = first.content.find((b) => b.type === "list");
+      expect(sublist).toBeDefined();
+      if (sublist && sublist.type === "list") {
+        expect(sublist.items.length).toBe(2);
       }
     }
+  });
+});
+
+describe("listParser nested blocks (minimum viable)", () => {
+  it("nests a fenced code block inside a list item", () => {
+    const input = [
+      "- Run this:",
+      "  ```ts",
+      "  node main()",
+      "  ```",
+    ].join("\n");
+    const res = listParser(input);
+    expect(res.success).toBe(true);
+    if (res.success) {
+      const item = res.result.items[0];
+      const types = item.content.map((b) => b.type);
+      expect(types).toEqual(["paragraph", "code-block"]);
+      const code = item.content[1] as any;
+      expect(code.language).toBe("ts");
+      expect(code.content).toBe("node main()\n");
+    }
+  });
+
+  it("nests a fenced code block inside a sub-list item (the README case)", () => {
+    const input = [
+      "- Quick Start:",
+      "  - Create a file:",
+      "    ```ts",
+      "    node main() {",
+      "      print(1);",
+      "    }",
+      "    ```",
+      "  - Run it.",
+    ].join("\n");
+    const res = listParser(input);
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.result.items.length).toBe(1);
+      const inner = res.result.items[0].content.find(
+        (b) => b.type === "list"
+      );
+      expect(inner).toBeDefined();
+      if (inner && inner.type === "list") {
+        expect(inner.items.length).toBe(2);
+        const firstInner = inner.items[0];
+        const types = firstInner.content.map((b) => b.type);
+        expect(types).toEqual(["paragraph", "code-block"]);
+        const code = firstInner.content[1] as any;
+        expect(code.language).toBe("ts");
+      }
+    }
+  });
+
+  it("nests a blockquote inside a list item", () => {
+    const input = [
+      "- top",
+      "  > quoted",
+    ].join("\n");
+    const res = listParser(input);
+    expect(res.success).toBe(true);
+    if (res.success) {
+      const types = res.result.items[0].content.map((b) => b.type);
+      expect(types).toEqual(["paragraph", "block-quote"]);
+    }
+  });
+
+  it("nests an ordered list inside an ordered item (k=3 continuation)", () => {
+    // For `1. outer` (marker col 0, width 2, one space): k = 3.
+    // Inner items at 3-space indent fall inside the outer item.
+    const input = [
+      "1. outer",
+      "   1. inner",
+      "   2. inner2",
+    ].join("\n");
+    const res = listParser(input);
+    expect(res.success).toBe(true);
+    if (res.success) {
+      // outer ordered list with one item that contains an inner ordered list
+      expect(res.result.ordered).toBe(true);
+      const outer = res.result.items[0];
+      const inner = outer.content.find((b) => b.type === "list");
+      expect(inner).toBeDefined();
+      if (inner && inner.type === "list") {
+        expect(inner.ordered).toBe(true);
+        expect(inner.items.length).toBe(2);
+      }
+    }
+  });
+
+  it("produces multiple paragraph blocks when items have blank-line-separated paragraphs", () => {
+    const input = ["- first para", "", "  second para"].join("\n");
+    const res = listParser(input);
+    expect(res.success).toBe(true);
+    if (res.success) {
+      const types = res.result.items[0].content.map((b) => b.type);
+      expect(types).toEqual(["paragraph", "paragraph"]);
+    }
+  });
+
+  // --- Negative cases ---
+
+  it("does not absorb a sibling item as continuation", () => {
+    // `- second` at column 0 is a new sibling, not part of the first item.
+    const res = listParser("- first\n- second\n");
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.result.items.length).toBe(2);
+      const firstTypes = res.result.items[0].content.map((b) => b.type);
+      expect(firstTypes).toEqual(["paragraph"]);
+    }
+  });
+
+  it("survives a trailing blank line after the last item", () => {
+    const res = listParser("- one\n- two\n\n");
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.result.items.length).toBe(2);
+    }
+  });
+
+  // --- Known-broken (out of scope per spec) ---
+
+  it.skip("[out of scope] handles lazy continuation of a paragraph in an item", () => {
+    // Properly correct: one list, two items, the first contains a two-line
+    // paragraph. Minimum viable produces: list(1) + paragraph + list(1).
+    // See docs/superpowers/plans/2026-06-05-markdown-nested-blocks-in-list-items.md
+    const input = [
+      "- This is the first item with a paragraph",
+      "that wraps onto a second line without indentation.",
+      "- Second item.",
+    ].join("\n");
+    const res = listParser(input);
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.result.items.length).toBe(2);
+    }
+  });
+
+  it.skip("[out of scope] distinguishes loose lists by wrapping items in paragraph nodes", () => {
+    // Loose vs tight lists not handled. See spec.
+    const tight = "- one\n- two\n";
+    const loose = "- one\n\n- two\n";
+    const t = listParser(tight);
+    const l = listParser(loose);
+    expect(t.success && l.success).toBe(true);
   });
 });
 

--- a/tests/parsers/markdown/index.test.ts
+++ b/tests/parsers/markdown/index.test.ts
@@ -98,9 +98,9 @@ describe("markdownParser integration", () => {
   });
 
   it("parses a list item followed by a 2-space-indented fenced code block", () => {
-    // Standard markdown list-item-continuation shape. The indented fence isn't
-    // recognised as a real code block (we don't dedent), but the parser must
-    // still consume the indented lines so `rest` ends up empty.
+    // The fence indented to the item's continuation column (k = 2) is now
+    // recognised as a nested block inside the item, not as a top-level
+    // sibling. Top-level result is `list` then `heading`.
     const input = [
       "- Use the command:",
       "  ```bash",
@@ -114,10 +114,13 @@ describe("markdownParser integration", () => {
     if (res.success) {
       expect(res.rest).toBe("");
       const types = (res.result as any[]).map((b) => b.type);
-      // The indented fence isn't dedented — its body falls through to a
-      // paragraph between the list and the next heading. The important
-      // invariant is that nothing is dropped on the floor.
-      expect(types).toEqual(["list", "paragraph", "heading"]);
+      expect(types).toEqual(["list", "heading"]);
+      const list = (res.result as any[])[0];
+      const itemContent = list.items[0].content as any[];
+      const itemTypes = itemContent.map((b) => b.type);
+      expect(itemTypes).toEqual(["paragraph", "code-block"]);
+      expect(itemContent[1].language).toBe("bash");
+      expect(itemContent[1].content).toBe("pnpm install agency-lang\n");
     }
   });
 


### PR DESCRIPTION
## Summary

- List items become containers of **blocks**, not a single line of inline content. A fenced code block (or any other block) indented to the item's continuation column `k = c + markerWidth + 1` parses as a child of that item rather than being pulled out to the document root.
- `ListItem.sublist` is removed. Nested lists appear in `ListItem.content` like any other block.
- One unified `itemParser` handles unordered and ordered lists; `Marker` carries `width` as data, so the marker-width-aware continuation indent works for multi-digit ordered markers too.

The README example in `example.md` now parses with the fenced TypeScript code block correctly nested inside the "Quick Start" sub-list item, rather than being orphaned as a top-level indented code block with `language: null`.

## Implementation notes

- The new list parser is combinator-first: `continuationLine(k)` consumes the indent via `indentOf(k)` as part of the parse (no manual `.slice(k)` stripping), `itemBody(k)` joins the collected lines and reparses them through `blockEntry`, and the whole thing mirrors `blockQuoteParser`'s line-prefixed recursive-container shape.
- `blockAlt` and `blockEntry` moved from `index.ts` into `blocks.ts` so the list parser can recurse through them via `lazy(() => blockEntry)` without an import cycle.
- `reparseBlocks` throws on a failed non-empty buffer rather than silently returning `[]` — CommonMark guarantees any non-empty buffer produces at least one block, so a failure here would be a parser bug worth surfacing.
- `Marker` now carries `width`; `itemParser` is handwritten (not `seqC`) because `k` is derived from the parsed marker — same shape as `inlineCodeParser` threading the opener's tick count into the closer.

## Out of scope (intentional)

Documented as `it.skip` in `tests/parsers/markdown/blocks.test.ts`:
- **Lazy continuation** — a paragraph line that wraps onto an un-indented next line is not recognized as continuing the paragraph.
- **Loose vs. tight lists** — blank lines between items don't promote item contents to `Paragraph` wrappers.
- **CommonMark edge cases around extra spaces** between marker and content (e.g. `1.  outer` widening k from 3 to 4).

## Test plan

- [x] `npx vitest run` — 471 passing, 2 skipped (the out-of-scope cases above), 0 failing.
- [x] `npx tsc --noEmit` clean.
- [x] Manual: the README example with a fenced code block in a sub-list item produces the expected nested AST (`item.content = [paragraph, code-block]` with `language: "ts"`).
- [x] Negative tests: sibling items at column 0 are not absorbed as continuations; trailing blank lines after the last item don't break the parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
